### PR TITLE
feat: add new click events and enhance README (fix Outdated #8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,11 +163,10 @@ customComponent := &component.Text{
 - **Performance optimized**: Much faster than Go's standard JSON encoding
 - **Comprehensive testing**: Extensive test coverage for all versions and formats
 
-### 🧪 Testing
+### 🧪 Testing, formatting, linting
 
 ```bash
-cd minecraft/component/codec
-go test -v
+make
 ```
 
 All format variations and cross-compatibility scenarios are thoroughly tested to ensure reliability across all Minecraft versions.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,173 @@
-# common
-
-Minekube's Commons Library
+# Minekube Commons Library
 
 **Get it:**
 `go get -u go.minekube.com/common`
 
-Libraries:
-- minecraft/component
-  - A Minecraft text components library.
-  - Marshal/Unmarshal in different formats
-    - json components (faster than Go's standard encoding/json,
-    thanks to [Gojay](https://github.com/francoispqt/gojay))
-    - plain text marshalling
-    - legacy colors & formats
-    - Minecraft 1.16+ hex colors
-    - click/hover events
-    - options for encoding/decoding
-    - support older Minecraft client versions by default!
+## Minecraft Text Components (`minecraft/component`)
+
+A comprehensive Minecraft text components library with **full multi-version support** for all Minecraft versions from legacy to the latest (1.21.6+).
+
+### 🎯 Key Features
+
+- **Complete Multi-Version Support**: Supports all Minecraft versions from legacy to 1.21.6+
+- **Backward & Forward Compatibility**: Can decode any format regardless of encoding settings
+- **Configurable Encoding**: Choose between formats for different Minecraft versions
+- **High Performance**: Uses optimized JSON marshalling (thanks to [Gojay](https://github.com/francoispqt/gojay))
+- **Complete Component Support**: Text, translation, click events, hover events, styling, and more
+- **Future-Ready**: Includes upcoming 1.21.6+ features like dialog and custom click events
+
+### 🚀 Quick Start
+
+```go
+import "go.minekube.com/common/minecraft/component/codec"
+
+// Create a codec for the latest format (1.21.5+)
+j := &codec.Json{
+    UseLegacyFieldNames:          false, // Use snake_case field names
+    UseLegacyClickEventStructure: false, // Use specific field names
+    UseLegacyHoverEventStructure: false, // Use inlined structure
+    StdJson:                      true,
+}
+
+// Create a text component with click and hover events
+component := &component.Text{
+    Content: "Click me!",
+    S: component.Style{
+        Color:      color.Green.RGB,
+        ClickEvent: component.OpenUrl("https://example.com"),
+        HoverEvent: component.ShowText(&component.Text{Content: "Tooltip"}),
+    },
+}
+
+// Encode to JSON
+var buf strings.Builder
+err := j.Marshal(&buf, component)
+// Output: {"text":"Click me!","color":"#55ff55","click_event":{"action":"open_url","url":"https://example.com"},"hover_event":{"action":"show_text","value":{"text":"Tooltip"}}}
+```
+
+### 📋 Supported Click Events
+
+| Action              | Legacy Field | Modern Field(s) | Version | Description                       |
+| ------------------- | ------------ | --------------- | ------- | --------------------------------- |
+| `open_url`          | `value`      | `url`           | 1.21.5+ | Opens URL in browser              |
+| `open_file`         | `value`      | `path`          | 1.21.5+ | Opens file (client-side only)     |
+| `run_command`       | `value`      | `command`       | 1.21.5+ | Executes command                  |
+| `suggest_command`   | `value`      | `command`       | 1.21.5+ | Suggests command in chat          |
+| `change_page`       | `value`      | `page`          | 1.21.5+ | Changes book page (int in modern) |
+| `copy_to_clipboard` | `value`      | `value`         | All     | Copies text (unchanged)           |
+| `show_dialog`       | `value`      | `dialog`        | 1.21.6+ | Opens dialog                      |
+| `custom`            | `value`      | `id`/`payload`  | 1.21.6+ | Custom server event               |
+
+### 🎛️ Version Configuration Examples
+
+**Latest Format (1.21.6+):**
+
+```go
+j := &codec.Json{
+    UseLegacyFieldNames:          false, // snake_case: click_event, hover_event
+    UseLegacyClickEventStructure: false, // Specific fields: url, path, command, etc.
+    UseLegacyHoverEventStructure: false, // Inlined hover structure
+    StdJson:                      true,
+}
+```
+
+**Legacy Format (Pre-1.21.5):**
+
+```go
+j := &codec.Json{
+    UseLegacyFieldNames:          true,  // camelCase: clickEvent, hoverEvent
+    UseLegacyClickEventStructure: true,  // Universal "value" field
+    UseLegacyHoverEventStructure: true,  // "contents" wrapper structure
+    NoLegacyHover:                false, // Include both contents and value
+    StdJson:                      true,
+}
+```
+
+**Universal Compatibility (Recommended):**
+
+```go
+j := &codec.Json{
+    // Encodes in modern format but can decode ANY format
+    UseLegacyFieldNames:          false,
+    UseLegacyClickEventStructure: false,
+    UseLegacyHoverEventStructure: false,
+    StdJson:                      true,
+}
+```
+
+### 🆕 New Minecraft 1.21.6 Features
+
+```go
+// Dialog click event (1.21.6+)
+dialogComponent := &component.Text{
+    Content: "Open Settings",
+    S: component.Style{
+        ClickEvent: component.ShowDialog("settings_dialog"),
+    },
+}
+
+// Custom server events (1.21.6+)
+customComponent := &component.Text{
+    Content: "Trigger Event",
+    S: component.Style{
+        ClickEvent: component.CustomEvent("my_event", "some_payload"),
+    },
+}
+```
+
+### 🔄 Format Examples
+
+**Modern Format (1.21.5+):**
+
+```json
+{
+  "text": "Click me",
+  "click_event": {
+    "action": "open_url",
+    "url": "https://example.com"
+  },
+  "hover_event": {
+    "action": "show_item",
+    "id": "minecraft:diamond",
+    "count": 5
+  }
+}
+```
+
+**Legacy Format (Pre-1.21.5):**
+
+```json
+{
+  "text": "Click me",
+  "clickEvent": {
+    "action": "open_url",
+    "value": "https://example.com"
+  },
+  "hoverEvent": {
+    "action": "show_item",
+    "contents": {
+      "id": "minecraft:diamond",
+      "count": 5
+    }
+  }
+}
+```
+
+### ✨ Additional Features
+
+- **Legacy colors & formats**: Support for legacy color codes
+- **Minecraft 1.16+ hex colors**: Full hex color support (`#ff5555`)
+- **Hover events**: `show_text`, `show_item`, `show_entity` with all format variations
+- **Translations**: Full translation component support with arguments
+- **Cross-version compatibility**: Decode any format, encode in your preferred format
+- **Performance optimized**: Much faster than Go's standard JSON encoding
+- **Comprehensive testing**: Extensive test coverage for all versions and formats
+
+### 🧪 Testing
+
+```bash
+cd minecraft/component/codec
+go test -v
+```
+
+All format variations and cross-compatibility scenarios are thoroughly tested to ensure reliability across all Minecraft versions.

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,6 @@ github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+u
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
-github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
-github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go v2.0.0+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=

--- a/minecraft/component/README.md
+++ b/minecraft/component/README.md
@@ -1,3 +1,0 @@
-# component
-
-A Minecraft text components library for the Go programming language.

--- a/minecraft/component/click.go
+++ b/minecraft/component/click.go
@@ -67,6 +67,18 @@ func CopyToClipboard(text string) ClickEvent {
 	return &clickEvent{CopyToClipboardAction, text}
 }
 
+func ShowDialog(dialog string) ClickEvent {
+	return &clickEvent{ShowDialogAction, dialog}
+}
+
+func CustomEvent(id string, payload ...string) ClickEvent {
+	value := id
+	if len(payload) > 0 && payload[0] != "" {
+		value = id + "|" + payload[0]
+	}
+	return &clickEvent{CustomEventAction, value}
+}
+
 var (
 	OpenUrlAction         ClickAction = &clickAction{"open_url", true}
 	OpenFileAction        ClickAction = &clickAction{"open_file", false}
@@ -74,6 +86,8 @@ var (
 	SuggestCommandAction  ClickAction = &clickAction{"suggest_command", true}
 	ChangePageAction      ClickAction = &clickAction{"change_page", true}
 	CopyToClipboardAction ClickAction = &clickAction{"copy_to_clipboard", true}
+	ShowDialogAction      ClickAction = &clickAction{"show_dialog", true}
+	CustomEventAction     ClickAction = &clickAction{"custom", true}
 
 	ClickActions = func() map[string]ClickAction {
 		m := map[string]ClickAction{}
@@ -84,6 +98,8 @@ var (
 			SuggestCommandAction,
 			ChangePageAction,
 			CopyToClipboardAction,
+			ShowDialogAction,
+			CustomEventAction,
 		} {
 			m[a.Name()] = a
 		}

--- a/minecraft/component/codec/json_test.go
+++ b/minecraft/component/codec/json_test.go
@@ -1,18 +1,58 @@
 package codec
 
 import (
-	"github.com/stretchr/testify/require"
-	. "go.minekube.com/common/minecraft/color"
-	. "go.minekube.com/common/minecraft/component"
 	"io/ioutil"
 	"strings"
 	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	. "go.minekube.com/common/minecraft/color"
+	. "go.minekube.com/common/minecraft/component"
+	"go.minekube.com/common/minecraft/key"
+	"go.minekube.com/common/minecraft/nbt"
 )
 
-var j = &Json{
-	NoLegacyHover:     true,
-	NoDownsampleColor: true,
-	StdJson:           true,
+// Test configurations for different Minecraft versions
+
+// Pre-1.21.5 format: camelCase field names with legacy structures
+var jPre1215 = &Json{
+	NoLegacyHover:                false, // Include both contents and value for compatibility
+	NoDownsampleColor:            true,
+	UseLegacyFieldNames:          true, // Use camelCase (clickEvent, hoverEvent)
+	UseLegacyClickEventStructure: true, // Use "value" field for click events
+	UseLegacyHoverEventStructure: true, // Use "contents" field for hover events
+	StdJson:                      true,
+}
+
+// 1.21.5+ format: snake_case field names with new structures
+var j1215Plus = &Json{
+	NoLegacyHover:                true, // Only new format, no legacy "value" field
+	NoDownsampleColor:            true,
+	UseLegacyFieldNames:          false, // Use snake_case (click_event, hover_event)
+	UseLegacyClickEventStructure: false, // Use specific fields (url, path, command, page)
+	UseLegacyHoverEventStructure: false, // Use inlined structure
+	StdJson:                      true,
+}
+
+// Compatibility decoder: can decode all formats but encodes in new format
+var jCompat = &Json{
+	NoLegacyHover:                true,
+	NoDownsampleColor:            true,
+	UseLegacyFieldNames:          false, // Encode with new format
+	UseLegacyClickEventStructure: false, // Encode with new structure
+	UseLegacyHoverEventStructure: false, // Encode with new structure
+	StdJson:                      true,
+}
+
+// Legacy decoder: can decode all formats but encodes in legacy format
+var jLegacyCompat = &Json{
+	NoLegacyHover:                false, // Include legacy fields for compatibility
+	NoDownsampleColor:            true,
+	UseLegacyFieldNames:          true, // Encode with legacy format
+	UseLegacyClickEventStructure: true, // Encode with legacy structure
+	UseLegacyHoverEventStructure: true, // Encode with legacy structure
+	StdJson:                      true,
 }
 
 func BenchmarkJson_Marshal(b *testing.B) {
@@ -36,7 +76,7 @@ func BenchmarkJson_Marshal(b *testing.B) {
 	}}
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		err := j.Marshal(ioutil.Discard, tx)
+		err := j1215Plus.Marshal(ioutil.Discard, tx)
 		require.NoError(b, err)
 	}
 }
@@ -69,18 +109,23 @@ var (
 			}),
 			Insertion: &insert,
 		}}
-	jsonTxt = `{"bold":false,"clickEvent":{"action":"suggest_command","value":"/help"},"color":"#55ffff","extra":[{"color":"#ff5555","italic":true,"obfuscated":false,"text":" there!"}],"font":"minecraft:default","hoverEvent":{"action":"show_text","contents":{"extra":[{"text":"!"}],"text":" world"}},"insertion":"insert me","italic":false,"obfuscated":true,"text":"Hello","underlined":true}`
+
+	// New format JSON (1.21.5+) - uses snake_case field names and new structures
+	jsonTxtNew = `{"bold":false,"click_event":{"action":"suggest_command","command":"/help"},"color":"#55ffff","extra":[{"color":"#ff5555","italic":true,"obfuscated":false,"text":" there!"}],"font":"minecraft:default","hover_event":{"action":"show_text","value":{"extra":[{"text":"!"}],"text":" world"}},"insertion":"insert me","italic":false,"obfuscated":true,"text":"Hello","underlined":true}`
+
+	// Legacy format JSON (pre-1.21.5) - uses camelCase field names and legacy structures
+	jsonTxtLegacy = `{"bold":false,"clickEvent":{"action":"suggest_command","value":"/help"},"color":"#55ffff","extra":[{"color":"#ff5555","italic":true,"obfuscated":false,"text":" there!"}],"font":"minecraft:default","hoverEvent":{"action":"show_text","contents":{"extra":[{"text":"!"}],"text":" world"},"value":{"extra":[{"text":"!"}],"text":" world"}},"insertion":"insert me","italic":false,"obfuscated":true,"text":"Hello","underlined":true}`
 )
 
 func TestJson_Marshal_text(t *testing.T) {
 	b := new(strings.Builder)
-	err := j.Marshal(b, txt)
+	err := j1215Plus.Marshal(b, txt)
 	require.NoError(t, err)
-	require.Equal(t, jsonTxt, b.String())
+	require.Equal(t, jsonTxtNew, b.String())
 }
 
 func TestJson_Unmarshal_text(t *testing.T) {
-	c, err := j.Unmarshal([]byte(jsonTxt))
+	c, err := j1215Plus.Unmarshal([]byte(jsonTxtNew))
 	require.NoError(t, err)
 	require.Equal(t, txt, c)
 }
@@ -100,11 +145,465 @@ func TestJson_translation(t *testing.T) {
 		},
 	}
 	s := new(strings.Builder)
-	require.NoError(t, j.Marshal(s, tr))
+	require.NoError(t, j1215Plus.Marshal(s, tr))
 	const exp = `{"color":"#ff5555","translate":"sample.key","with":[{"text":"Hello"},{"translate":"another.key"}]}`
 	require.Equal(t, exp, s.String())
 
-	tr2, err := j.Unmarshal([]byte(exp))
+	tr2, err := j1215Plus.Unmarshal([]byte(exp))
 	require.NoError(t, err)
 	require.Equal(t, tr, tr2)
+}
+
+// Test encoding with new format (1.21.5+)
+func TestJson_Marshal_NewFormat(t *testing.T) {
+	b := new(strings.Builder)
+	err := j1215Plus.Marshal(b, txt)
+	require.NoError(t, err)
+	require.Equal(t, jsonTxtNew, b.String())
+	require.Contains(t, b.String(), `"click_event":`)
+	require.Contains(t, b.String(), `"hover_event":`)
+}
+
+// Test encoding with legacy format (pre-1.21.5)
+func TestJson_Marshal_LegacyFormat(t *testing.T) {
+	b := new(strings.Builder)
+	err := jPre1215.Marshal(b, txt)
+	require.NoError(t, err)
+	require.Equal(t, jsonTxtLegacy, b.String())
+	require.Contains(t, b.String(), `"clickEvent":`)
+	require.Contains(t, b.String(), `"hoverEvent":`)
+}
+
+// Test decoding new format with new codec
+func TestJson_Unmarshal_NewFormat(t *testing.T) {
+	c, err := j1215Plus.Unmarshal([]byte(jsonTxtNew))
+	require.NoError(t, err)
+	require.Equal(t, txt, c)
+}
+
+// Test decoding legacy format with legacy codec
+func TestJson_Unmarshal_LegacyFormat(t *testing.T) {
+	c, err := jPre1215.Unmarshal([]byte(jsonTxtLegacy))
+	require.NoError(t, err)
+	require.Equal(t, txt, c)
+}
+
+// Test cross-compatibility: decode new format with legacy codec
+func TestJson_CrossCompat_NewFormatWithLegacyCodec(t *testing.T) {
+	c, err := jPre1215.Unmarshal([]byte(jsonTxtNew))
+	require.NoError(t, err)
+	require.Equal(t, txt, c)
+}
+
+// Test cross-compatibility: decode legacy format with new codec
+func TestJson_CrossCompat_LegacyFormatWithNewCodec(t *testing.T) {
+	c, err := j1215Plus.Unmarshal([]byte(jsonTxtLegacy))
+	require.NoError(t, err)
+	require.Equal(t, txt, c)
+}
+
+// Test cross-compatibility: decode both formats with compatibility codec
+func TestJson_CrossCompat_BothFormatsWithCompatCodec(t *testing.T) {
+	// Test new format
+	c1, err := jCompat.Unmarshal([]byte(jsonTxtNew))
+	require.NoError(t, err)
+	require.Equal(t, txt, c1)
+
+	// Test legacy format
+	c2, err := jCompat.Unmarshal([]byte(jsonTxtLegacy))
+	require.NoError(t, err)
+	require.Equal(t, txt, c2)
+}
+
+// Test round-trip: encode with one format, decode with another
+func TestJson_RoundTrip_CrossFormat(t *testing.T) {
+	// Encode with legacy, decode with new
+	legacyEncoded := new(strings.Builder)
+	err := jPre1215.Marshal(legacyEncoded, txt)
+	require.NoError(t, err)
+
+	decoded, err := j1215Plus.Unmarshal([]byte(legacyEncoded.String()))
+	require.NoError(t, err)
+	require.Equal(t, txt, decoded)
+
+	// Encode with new, decode with legacy
+	newEncoded := new(strings.Builder)
+	err = j1215Plus.Marshal(newEncoded, txt)
+	require.NoError(t, err)
+
+	decoded2, err := jPre1215.Unmarshal([]byte(newEncoded.String()))
+	require.NoError(t, err)
+	require.Equal(t, txt, decoded2)
+}
+
+// Test that click events work in both formats
+func TestJson_ClickEvent_BothFormats(t *testing.T) {
+	component := &Text{
+		Content: "Click me",
+		S: Style{
+			ClickEvent: CopyToClipboard("test"),
+		},
+	}
+
+	// Test new format
+	newEncoded := new(strings.Builder)
+	err := j1215Plus.Marshal(newEncoded, component)
+	require.NoError(t, err)
+	require.Contains(t, newEncoded.String(), `"click_event":`)
+	require.Contains(t, newEncoded.String(), `"copy_to_clipboard"`)
+
+	decoded, err := j1215Plus.Unmarshal([]byte(newEncoded.String()))
+	require.NoError(t, err)
+	require.Equal(t, component, decoded)
+
+	// Test legacy format
+	legacyEncoded := new(strings.Builder)
+	err = jPre1215.Marshal(legacyEncoded, component)
+	require.NoError(t, err)
+	require.Contains(t, legacyEncoded.String(), `"clickEvent":`)
+	require.Contains(t, legacyEncoded.String(), `"copy_to_clipboard"`)
+
+	decoded2, err := jPre1215.Unmarshal([]byte(legacyEncoded.String()))
+	require.NoError(t, err)
+	require.Equal(t, component, decoded2)
+}
+
+// Test that hover events work in both formats
+func TestJson_HoverEvent_BothFormats(t *testing.T) {
+	component := &Text{
+		Content: "Hover me",
+		S: Style{
+			HoverEvent: ShowText(&Text{Content: "Tooltip"}),
+		},
+	}
+
+	// Test new format
+	newEncoded := new(strings.Builder)
+	err := j1215Plus.Marshal(newEncoded, component)
+	require.NoError(t, err)
+	require.Contains(t, newEncoded.String(), `"hover_event":`)
+	require.Contains(t, newEncoded.String(), `"show_text"`)
+
+	decoded, err := j1215Plus.Unmarshal([]byte(newEncoded.String()))
+	require.NoError(t, err)
+	require.Equal(t, component, decoded)
+
+	// Test legacy format
+	legacyEncoded := new(strings.Builder)
+	err = jPre1215.Marshal(legacyEncoded, component)
+	require.NoError(t, err)
+	require.Contains(t, legacyEncoded.String(), `"hoverEvent":`)
+	require.Contains(t, legacyEncoded.String(), `"show_text"`)
+
+	decoded2, err := jPre1215.Unmarshal([]byte(legacyEncoded.String()))
+	require.NoError(t, err)
+	require.Equal(t, component, decoded2)
+}
+
+// Test all click event actions in different formats
+func TestJson_ClickEvent_AllActions(t *testing.T) {
+	testCases := []struct {
+		name      string
+		component *Text
+		action    string
+		value     string
+	}{
+		{
+			name: "open_url",
+			component: &Text{
+				Content: "Open URL",
+				S:       Style{ClickEvent: OpenUrl("https://example.com")},
+			},
+			action: "open_url",
+			value:  "https://example.com",
+		},
+		{
+			name: "run_command",
+			component: &Text{
+				Content: "Run Command",
+				S:       Style{ClickEvent: RunCommand("/say hello")},
+			},
+			action: "run_command",
+			value:  "/say hello",
+		},
+		{
+			name: "suggest_command",
+			component: &Text{
+				Content: "Suggest Command",
+				S:       Style{ClickEvent: SuggestCommand("/help")},
+			},
+			action: "suggest_command",
+			value:  "/help",
+		},
+		{
+			name: "copy_to_clipboard",
+			component: &Text{
+				Content: "Copy Text",
+				S:       Style{ClickEvent: CopyToClipboard("copied text")},
+			},
+			action: "copy_to_clipboard",
+			value:  "copied text",
+		},
+		{
+			name: "change_page",
+			component: &Text{
+				Content: "Change Page",
+				S:       Style{ClickEvent: ChangePage("3")},
+			},
+			action: "change_page",
+			value:  "3",
+		},
+		{
+			name: "show_dialog",
+			component: &Text{
+				Content: "Show Dialog",
+				S:       Style{ClickEvent: ShowDialog("my_dialog_id")},
+			},
+			action: "show_dialog",
+			value:  "my_dialog_id",
+		},
+		{
+			name: "custom",
+			component: &Text{
+				Content: "Custom Event",
+				S:       Style{ClickEvent: CustomEvent("my_event", "some_payload")},
+			},
+			action: "custom",
+			value:  "my_event|some_payload",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Test pre-1.21.5 format
+			t.Run("pre_1215_format", func(t *testing.T) {
+				encoded := new(strings.Builder)
+				err := jPre1215.Marshal(encoded, tc.component)
+				require.NoError(t, err)
+
+				// Should contain legacy field names and structure
+				require.Contains(t, encoded.String(), `"clickEvent"`)
+				require.Contains(t, encoded.String(), `"action":"`+tc.action+`"`)
+				require.Contains(t, encoded.String(), `"value":"`+tc.value+`"`)
+
+				// Should be decodable
+				decoded, err := jPre1215.Unmarshal([]byte(encoded.String()))
+				require.NoError(t, err)
+				require.Equal(t, tc.component, decoded)
+			})
+
+			// Test 1.21.5+ format
+			t.Run("1215_plus_format", func(t *testing.T) {
+				encoded := new(strings.Builder)
+				err := j1215Plus.Marshal(encoded, tc.component)
+				require.NoError(t, err)
+
+				// Should contain new field names
+				require.Contains(t, encoded.String(), `"click_event"`)
+				require.Contains(t, encoded.String(), `"action":"`+tc.action+`"`)
+
+				// Check for specific field names based on action
+				switch tc.action {
+				case "open_url":
+					require.Contains(t, encoded.String(), `"url":"`+tc.value+`"`)
+				case "run_command", "suggest_command":
+					require.Contains(t, encoded.String(), `"command":"`+tc.value+`"`)
+				case "change_page":
+					require.Contains(t, encoded.String(), `"page":3`) // Should be converted to int
+				case "copy_to_clipboard":
+					require.Contains(t, encoded.String(), `"value":"`+tc.value+`"`) // Still uses "value"
+				}
+
+				// Should be decodable
+				decoded, err := j1215Plus.Unmarshal([]byte(encoded.String()))
+				require.NoError(t, err)
+				require.Equal(t, tc.component, decoded)
+			})
+
+			// Test cross-compatibility
+			t.Run("cross_compatibility", func(t *testing.T) {
+				// Encode with legacy, decode with new
+				legacyEncoded := new(strings.Builder)
+				err := jPre1215.Marshal(legacyEncoded, tc.component)
+				require.NoError(t, err)
+
+				decoded1, err := j1215Plus.Unmarshal([]byte(legacyEncoded.String()))
+				require.NoError(t, err)
+				require.Equal(t, tc.component, decoded1)
+
+				// Encode with new, decode with legacy
+				newEncoded := new(strings.Builder)
+				err = j1215Plus.Marshal(newEncoded, tc.component)
+				require.NoError(t, err)
+
+				decoded2, err := jPre1215.Unmarshal([]byte(newEncoded.String()))
+				require.NoError(t, err)
+				require.Equal(t, tc.component, decoded2)
+			})
+		})
+	}
+}
+
+// Test all hover event actions in different formats
+func TestJson_HoverEvent_AllActions(t *testing.T) {
+	// Test show_text hover event
+	t.Run("show_text", func(t *testing.T) {
+		component := &Text{
+			Content: "Hover for text",
+			S: Style{
+				HoverEvent: ShowText(&Text{Content: "Tooltip text", S: Style{Color: Red.RGB}}),
+			},
+		}
+
+		// Test pre-1.21.5 format (uses "contents" field)
+		t.Run("pre_1215_format", func(t *testing.T) {
+			encoded := new(strings.Builder)
+			err := jPre1215.Marshal(encoded, component)
+			require.NoError(t, err)
+
+			// Should contain legacy structure
+			require.Contains(t, encoded.String(), `"hoverEvent"`)
+			require.Contains(t, encoded.String(), `"action":"show_text"`)
+			require.Contains(t, encoded.String(), `"contents"`)
+
+			decoded, err := jPre1215.Unmarshal([]byte(encoded.String()))
+			require.NoError(t, err)
+			require.Equal(t, component, decoded)
+		})
+
+		// Test 1.21.5+ format (uses inlined "value" field)
+		t.Run("1215_plus_format", func(t *testing.T) {
+			encoded := new(strings.Builder)
+			err := j1215Plus.Marshal(encoded, component)
+			require.NoError(t, err)
+
+			// Should contain new structure
+			require.Contains(t, encoded.String(), `"hover_event"`)
+			require.Contains(t, encoded.String(), `"action":"show_text"`)
+			require.Contains(t, encoded.String(), `"value"`) // Direct value field, not contents
+			require.NotContains(t, encoded.String(), `"contents"`)
+
+			decoded, err := j1215Plus.Unmarshal([]byte(encoded.String()))
+			require.NoError(t, err)
+			require.Equal(t, component, decoded)
+		})
+	})
+
+	// Test show_item hover event
+	t.Run("show_item", func(t *testing.T) {
+		itemKey, _ := key.Parse("minecraft:diamond")
+		component := &Text{
+			Content: "Hover for item",
+			S: Style{
+				HoverEvent: ShowItem(&ShowItemHoverType{
+					Item:  itemKey,
+					Count: 5,
+					NBT:   nbt.NewBinaryTagHolder("{display:{Name:\"Special Diamond\"}}"),
+				}),
+			},
+		}
+
+		// Test pre-1.21.5 format (uses "contents" field)
+		t.Run("pre_1215_format", func(t *testing.T) {
+			encoded := new(strings.Builder)
+			err := jPre1215.Marshal(encoded, component)
+			require.NoError(t, err)
+
+			// Should contain legacy structure
+			require.Contains(t, encoded.String(), `"hoverEvent"`)
+			require.Contains(t, encoded.String(), `"action":"show_item"`)
+			require.Contains(t, encoded.String(), `"contents"`)
+			require.Contains(t, encoded.String(), `"minecraft:diamond"`)
+
+			decoded, err := jPre1215.Unmarshal([]byte(encoded.String()))
+			require.NoError(t, err)
+			require.Equal(t, component, decoded)
+		})
+
+		// Test 1.21.5+ format (inlined fields)
+		t.Run("1215_plus_format", func(t *testing.T) {
+			encoded := new(strings.Builder)
+			err := j1215Plus.Marshal(encoded, component)
+			require.NoError(t, err)
+
+			// Should contain new inlined structure
+			require.Contains(t, encoded.String(), `"hover_event"`)
+			require.Contains(t, encoded.String(), `"action":"show_item"`)
+			require.Contains(t, encoded.String(), `"id":"minecraft:diamond"`) // Direct field
+			require.Contains(t, encoded.String(), `"count":5`)                // Direct field
+			require.NotContains(t, encoded.String(), `"contents"`)
+
+			decoded, err := j1215Plus.Unmarshal([]byte(encoded.String()))
+			require.NoError(t, err)
+			require.Equal(t, component, decoded)
+		})
+	})
+
+	// Test show_entity hover event
+	t.Run("show_entity", func(t *testing.T) {
+		uuid := uuid.MustParse("12345678-1234-1234-1234-123456789abc")
+		entityKey, _ := key.Parse("minecraft:player")
+		component := &Text{
+			Content: "Hover for entity",
+			S: Style{
+				HoverEvent: ShowEntity(&ShowEntityHoverType{
+					Type: entityKey,
+					Id:   uuid,
+					Name: &Text{Content: "TestPlayer", S: Style{Color: Blue.RGB}},
+				}),
+			},
+		}
+
+		// Test pre-1.21.5 format (uses "contents" with old field names)
+		t.Run("pre_1215_format", func(t *testing.T) {
+			encoded := new(strings.Builder)
+			err := jPre1215.Marshal(encoded, component)
+			require.NoError(t, err)
+
+			// Should contain legacy structure with old field names
+			require.Contains(t, encoded.String(), `"hoverEvent"`)
+			require.Contains(t, encoded.String(), `"action":"show_entity"`)
+			require.Contains(t, encoded.String(), `"contents"`)
+			require.Contains(t, encoded.String(), `"type":"minecraft:player"`)                   // Legacy field name
+			require.Contains(t, encoded.String(), `"id":"12345678-1234-1234-1234-123456789abc"`) // Legacy field name
+
+			decoded, err := jPre1215.Unmarshal([]byte(encoded.String()))
+			require.NoError(t, err)
+			require.Equal(t, component, decoded)
+		})
+
+		// Test 1.21.5+ format (inlined with new field names)
+		t.Run("1215_plus_format", func(t *testing.T) {
+			encoded := new(strings.Builder)
+			err := j1215Plus.Marshal(encoded, component)
+			require.NoError(t, err)
+
+			// Should contain new inlined structure with new field names
+			require.Contains(t, encoded.String(), `"hover_event"`)
+			require.Contains(t, encoded.String(), `"action":"show_entity"`)
+			require.Contains(t, encoded.String(), `"id":"minecraft:player"`)                       // New field name (was "type")
+			require.Contains(t, encoded.String(), `"uuid":"12345678-1234-1234-1234-123456789abc"`) // New field name (was "id")
+			require.NotContains(t, encoded.String(), `"contents"`)
+			require.NotContains(t, encoded.String(), `"type":"minecraft:player"`) // Should not use legacy field name
+
+			decoded, err := j1215Plus.Unmarshal([]byte(encoded.String()))
+			require.NoError(t, err)
+			require.Equal(t, component, decoded)
+		})
+
+		// Test cross-compatibility for field name changes
+		t.Run("cross_compatibility_field_names", func(t *testing.T) {
+			// Test that new decoder can read legacy field names
+			legacyJSON := `{"text":"Hover for entity","hover_event":{"action":"show_entity","contents":{"type":"minecraft:player","id":"12345678-1234-1234-1234-123456789abc","name":{"text":"TestPlayer","color":"#5555ff"}}}}`
+			decoded, err := j1215Plus.Unmarshal([]byte(legacyJSON))
+			require.NoError(t, err)
+			require.Equal(t, component, decoded)
+
+			// Test that legacy decoder can read new field names
+			newJSON := `{"text":"Hover for entity","hover_event":{"action":"show_entity","id":"minecraft:player","uuid":"12345678-1234-1234-1234-123456789abc","name":{"text":"TestPlayer","color":"#5555ff"}}}`
+			decoded2, err := jPre1215.Unmarshal([]byte(newJSON))
+			require.NoError(t, err)
+			require.Equal(t, component, decoded2)
+		})
+	})
 }

--- a/minecraft/component/example_new_actions_test.go
+++ b/minecraft/component/example_new_actions_test.go
@@ -1,0 +1,167 @@
+package component_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	. "go.minekube.com/common/minecraft/component"
+	"go.minekube.com/common/minecraft/component/codec"
+)
+
+// Example demonstrating the new Minecraft 1.21.6 click event actions
+func Example_newClickEventActions() {
+	// Modern codec for 1.21.6+ features
+	j := &codec.Json{
+		NoDownsampleColor:            true,
+		UseLegacyFieldNames:          false, // Use snake_case field names
+		UseLegacyClickEventStructure: false, // Use specific field names
+		StdJson:                      true,
+	}
+
+	// show_dialog action (1.21.6+)
+	dialogComponent := &Text{
+		Content: "Open Dialog",
+		S: Style{
+			ClickEvent: ShowDialog("my_custom_dialog"),
+		},
+	}
+
+	// custom action (1.21.6+) - with payload
+	customComponentWithPayload := &Text{
+		Content: "Custom Event with Payload",
+		S: Style{
+			ClickEvent: CustomEvent("my_event", "some_data"),
+		},
+	}
+
+	// custom action (1.21.6+) - without payload
+	customComponentSimple := &Text{
+		Content: "Simple Custom Event",
+		S: Style{
+			ClickEvent: CustomEvent("simple_event"),
+		},
+	}
+
+	// Encode dialog action
+	dialogJSON := new(strings.Builder)
+	err := j.Marshal(dialogJSON, dialogComponent)
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+
+	// Encode custom action with payload
+	customWithPayloadJSON := new(strings.Builder)
+	err = j.Marshal(customWithPayloadJSON, customComponentWithPayload)
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+
+	// Encode simple custom action
+	simpleCustomJSON := new(strings.Builder)
+	err = j.Marshal(simpleCustomJSON, customComponentSimple)
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+
+	fmt.Printf("Dialog Action (1.21.6+):\n%s\n\n", dialogJSON.String())
+	fmt.Printf("Custom Action with Payload (1.21.6+):\n%s\n\n", customWithPayloadJSON.String())
+	fmt.Printf("Simple Custom Action (1.21.6+):\n%s\n\n", simpleCustomJSON.String())
+
+	// Output:
+	// Dialog Action (1.21.6+):
+	// {"click_event":{"action":"show_dialog","dialog":"my_custom_dialog"},"text":"Open Dialog"}
+	//
+	// Custom Action with Payload (1.21.6+):
+	// {"click_event":{"action":"custom","id":"my_event","payload":"some_data"},"text":"Custom Event with Payload"}
+	//
+	// Simple Custom Action (1.21.6+):
+	// {"click_event":{"action":"custom","id":"simple_event"},"text":"Simple Custom Event"}
+}
+
+func TestNewClickEventActions_1216(t *testing.T) {
+	// Test the new 1.21.6 actions in both formats
+	j1216 := &codec.Json{
+		UseLegacyFieldNames:          false, // Modern format
+		UseLegacyClickEventStructure: false,
+		StdJson:                      true,
+	}
+
+	jLegacy := &codec.Json{
+		UseLegacyFieldNames:          true, // Legacy format
+		UseLegacyClickEventStructure: true,
+		StdJson:                      true,
+	}
+
+	// Test show_dialog action
+	t.Run("show_dialog", func(t *testing.T) {
+		component := &Text{
+			Content: "Show Dialog",
+			S:       Style{ClickEvent: ShowDialog("test_dialog")},
+		}
+
+		// Test modern format
+		modern := new(strings.Builder)
+		err := j1216.Marshal(modern, component)
+		if err != nil {
+			t.Fatalf("Failed to marshal show_dialog in modern format: %v", err)
+		}
+
+		if !strings.Contains(modern.String(), `"dialog":"test_dialog"`) {
+			t.Errorf("Modern format should contain dialog field, got: %s", modern.String())
+		}
+
+		// Test legacy format (should fallback to value field)
+		legacy := new(strings.Builder)
+		err = jLegacy.Marshal(legacy, component)
+		if err != nil {
+			t.Fatalf("Failed to marshal show_dialog in legacy format: %v", err)
+		}
+
+		if !strings.Contains(legacy.String(), `"value":"test_dialog"`) {
+			t.Errorf("Legacy format should contain value field, got: %s", legacy.String())
+		}
+
+		// Test round-trip compatibility
+		decoded, err := j1216.Unmarshal([]byte(modern.String()))
+		if err != nil {
+			t.Fatalf("Failed to unmarshal modern format: %v", err)
+		}
+
+		if decoded.(*Text).S.ClickEvent.Value() != "test_dialog" {
+			t.Errorf("Round-trip failed, expected 'test_dialog', got '%s'", decoded.(*Text).S.ClickEvent.Value())
+		}
+	})
+
+	// Test custom action
+	t.Run("custom", func(t *testing.T) {
+		component := &Text{
+			Content: "Custom Event",
+			S:       Style{ClickEvent: CustomEvent("my_id", "my_payload")},
+		}
+
+		// Test modern format
+		modern := new(strings.Builder)
+		err := j1216.Marshal(modern, component)
+		if err != nil {
+			t.Fatalf("Failed to marshal custom in modern format: %v", err)
+		}
+
+		if !strings.Contains(modern.String(), `"id":"my_id"`) || !strings.Contains(modern.String(), `"payload":"my_payload"`) {
+			t.Errorf("Modern format should contain id and payload fields, got: %s", modern.String())
+		}
+
+		// Test round-trip compatibility
+		decoded, err := j1216.Unmarshal([]byte(modern.String()))
+		if err != nil {
+			t.Fatalf("Failed to unmarshal modern format: %v", err)
+		}
+
+		if decoded.(*Text).S.ClickEvent.Value() != "my_id|my_payload" {
+			t.Errorf("Round-trip failed, expected 'my_id|my_payload', got '%s'", decoded.(*Text).S.ClickEvent.Value())
+		}
+	})
+}


### PR DESCRIPTION
fix #8 

- Introduced `ShowDialog` and `CustomEvent` click events to support new functionalities.
- Updated README to reflect comprehensive features, version compatibility, and usage examples for the Minecraft text components library.
- Enhanced codec to handle new click event structures and maintain backward compatibility with legacy formats.