### PR TITLE
Add support for keybind component

### DIFF
--- a/minecraft/component/codec/json.go
+++ b/minecraft/component/codec/json.go
@@ -302,6 +302,8 @@ func (j *Json) encode(o obj, c Component) (err error) {
 		return j.encodeText(o, t)
 	case *Translation:
 		return j.encodeTranslation(o, t)
+	case *Keybind:
+		return j.encodeKeybind(o, t)
 	default:
 		return fmt.Errorf("codec.Json marshal: unsupported component type %T", c)
 	}
@@ -314,6 +316,8 @@ const (
 
 	translate     = "translate"
 	translateWith = "with"
+
+	keybind = "keybind"
 
 	font      = "font"
 	color     = "color"
@@ -381,6 +385,14 @@ func (j *Json) encodeTranslation(o obj, t *Translation) error {
 	}
 	o[translate] = t.Key
 	return j.encodeComponent(o, t, translateWith)
+}
+
+func (j *Json) encodeKeybind(o obj, t *Keybind) error {
+	if t == nil {
+		return nil
+	}
+	o[keybind] = t.Key
+	return j.encodeComponent(o, t, extra)
 }
 
 func (j *Json) encodeComponent(o obj, c Component, childrenKey string) (err error) {
@@ -680,6 +692,8 @@ func (j *Json) decodeComponent(o obj) (c Component, err error) {
 		} else {
 			c = &Translation{Key: k}
 		}
+	} else if o.Has(keybind) {
+		c = &Keybind{Key: fmt.Sprint(o[keybind])}
 	} else {
 		c = &Text{}
 	}

--- a/minecraft/component/codec/json_test.go
+++ b/minecraft/component/codec/json_test.go
@@ -123,6 +123,30 @@ func TestJson_translation(t *testing.T) {
 	require.Equal(t, tr, tr2)
 }
 
+func TestJson_keybind(t *testing.T) {
+	kb := &Text{
+		Content: "Press ",
+		Extra: []Component{
+			&Keybind{
+				Key: "key.jump",
+				S: Style{
+					Color: Red.RGB,
+				},
+			},
+			&Text{Content: " to jump"},
+		},
+	}
+
+	s := new(strings.Builder)
+	require.NoError(t, j1215Plus.Marshal(s, kb))
+	const exp = `{"extra":[{"color":"#ff5555","keybind":"key.jump"},{"text":" to jump"}],"text":"Press "}`
+	require.Equal(t, exp, s.String())
+
+	kb2, err := j1215Plus.Unmarshal([]byte(exp))
+	require.NoError(t, err)
+	require.Equal(t, kb, kb2)
+}
+
 // Test encoding with new format (1.21.5+)
 func TestJson_Marshal_NewFormat(t *testing.T) {
 	b := new(strings.Builder)

--- a/minecraft/component/component.go
+++ b/minecraft/component/component.go
@@ -24,6 +24,12 @@ type Translation struct {
 	With []Component
 }
 
+type Keybind struct {
+	Key   string // Keybind identifier
+	S     Style
+	Extra []Component
+}
+
 func (t *Text) Children() []Component {
 	return t.Extra
 }
@@ -44,14 +50,28 @@ func (t *Translation) SetChildren(children []Component) {
 	t.With = children
 }
 
+func (k *Keybind) Children() []Component {
+	return k.Extra
+}
+func (k *Keybind) Style() *Style {
+	return &k.S
+}
+func (k *Keybind) SetChildren(children []Component) {
+	k.Extra = children
+}
+
 var (
 	_ json.Marshaler   = (*Text)(nil)
 	_ json.Unmarshaler = (*Text)(nil)
 	_ json.Marshaler   = (*Translation)(nil)
 	_ json.Unmarshaler = (*Translation)(nil)
+	_ json.Marshaler   = (*Keybind)(nil)
+	_ json.Unmarshaler = (*Keybind)(nil)
 )
 
 func (t *Text) MarshalJSON() ([]byte, error)        { panic("use codec.Json instead") }
 func (t *Text) UnmarshalJSON(b []byte) error        { panic("use codec.Json instead") }
 func (t *Translation) UnmarshalJSON(b []byte) error { panic("use codec.Json instead") }
 func (t *Translation) MarshalJSON() ([]byte, error) { panic("use codec.Json instead") }
+func (k *Keybind) UnmarshalJSON(_ []byte) error     { panic("use codec.Json instead") }
+func (k *Keybind) MarshalJSON() ([]byte, error)     { panic("use codec.Json instead") }


### PR DESCRIPTION
I'm currently writing a full port of MiniMessage to Go, with all features supported (well, as far as it's possible; things that require component resolution either won't be supported, or only via a custom provider) and therefore I'll add a good amount of features into minekube/common. I'll send another PR after this to have the translate component support the `fallback` field.

If you'd like me to just send one big PR, with every feature it in, I'll be happy to do that too, just thought one feature per PR would be better for organization. 