### PR TITLE
Modernize Minecraft text component support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,23 +5,23 @@
 
 ## Minecraft Text Components (`minecraft/component`)
 
-A comprehensive Minecraft text components library with **full multi-version support** for all Minecraft versions from legacy to the latest (1.21.6+).
+A comprehensive Minecraft text components library with **multi-version support** for Minecraft text component formats from legacy JSON through modern object components.
 
 ### 🎯 Key Features
 
-- **Complete Multi-Version Support**: Supports all Minecraft versions from legacy to 1.21.6+
+- **Multi-Version Support**: Supports legacy JSON through modern 1.21.9+/26.1 component shapes
 - **Backward & Forward Compatibility**: Can decode any format regardless of encoding settings
 - **Configurable Encoding**: Choose between formats for different Minecraft versions
 - **High Performance**: Uses optimized JSON marshalling (thanks to [Gojay](https://github.com/francoispqt/gojay))
-- **Complete Component Support**: Text, translation, click events, hover events, styling, and more
-- **Future-Ready**: Includes upcoming 1.21.6+ features like dialog and custom click events
+- **Complete Component Support**: Text, translation, score, selector, keybind, NBT, object, click/hover events, styling, and more
+- **Modern Object Components**: Supports 1.21.9+ atlas sprites/player heads and 26.1 object fallbacks
 
 ### 🚀 Quick Start
 
 ```go
 import "go.minekube.com/common/minecraft/component/codec"
 
-// Create a codec for the latest format (1.21.5+)
+// Create a codec for the modern format (1.21.5+)
 j := &codec.Json{
     UseLegacyFieldNames:          false, // Use snake_case field names
     UseLegacyClickEventStructure: false, // Use specific field names
@@ -58,6 +58,18 @@ err := j.Marshal(&buf, component)
 | `show_dialog`       | `value`      | `dialog`        | 1.21.6+ | Opens dialog                      |
 | `custom`            | `value`      | `id`/`payload`  | 1.21.6+ | Custom server event               |
 
+### 📦 Supported Content Types
+
+| Component type | JSON key(s) | Notes |
+| -------------- | ----------- | ----- |
+| Text | `text` | Also decodes JSON string, boolean, and number shorthands |
+| Translation | `translate`, `fallback`, `with` | Supports 1.19.4+ fallback |
+| Score | `score` | Includes obsolete `value` for compatibility |
+| Selector | `selector`, `separator` | Supports component separator |
+| Keybind | `keybind` | Client-local keybind rendering |
+| NBT | `nbt`, `block`/`entity`/`storage`, `interpret`, `plain`, `separator` | Supports 26.1 `plain` |
+| Object | `object`, `atlas`/`sprite`, `player`, `hat`, `fallback` | Supports 1.21.9+ sprites/player heads and 26.1 fallback |
+
 ### 🎛️ Version Configuration Examples
 
 **Using Preset Configurations (Recommended):**
@@ -74,7 +86,7 @@ j := codec.JsonPre1_20_3
 // For clients 1.20.3+ but before 1.21.5
 j := codec.JsonPre1_21_5
 
-// For clients 1.21.5+ (latest format)
+// For clients 1.21.5+ (modern format)
 j := codec.JsonModern
 
 // Universal compatibility (encodes modern, decodes all)
@@ -84,7 +96,7 @@ j := codec.JsonUniversal
 **Manual Configuration:**
 
 ```go
-// Latest Format (1.21.6+)
+// Modern Format (1.21.5+ base, with newer component types supported)
 j := &codec.Json{
     UseLegacyFieldNames:          false, // snake_case: click_event, hover_event
     UseLegacyClickEventStructure: false, // Specific fields: url, path, command, etc.
@@ -164,7 +176,7 @@ j := &codec.Json{
 - `ShadowColorEmitModeInteger` - Emit as packed ARGB integer
 - `ShadowColorEmitModeArray` - Emit as `[r, g, b, a]` float array
 
-### 🆕 New Minecraft 1.21.6 Features
+### 🆕 Modern Minecraft Features
 
 ```go
 // Dialog click event (1.21.6+)
@@ -182,11 +194,70 @@ customComponent := &component.Text{
         ClickEvent: component.CustomEvent("my_event", "some_payload"),
     },
 }
+
+// Atlas sprite object component (1.21.9+), usable for item/block sprites in text
+atlas, _ := key.Parse("minecraft:blocks")
+sprite, _ := key.Parse("minecraft:item/diamond")
+spriteComponent := component.AtlasSprite(atlas, sprite)
+
+// Player head object component with a 26.1 fallback for contexts like server MOTDs
+playerComponent := component.PlayerHead(&component.PlayerProfile{Name: "jeb_"}, true)
+playerComponent.Fallback = &component.Text{Content: "jeb_"}
+
+// Score, selector, keybind, and NBT content types
+scoreComponent := &component.Score{Name: "@s", Objective: "kills"}
+selectorComponent := &component.Selector{Pattern: "@a", Separator: &component.Text{Content: ", "}}
+keybindComponent := &component.Keybind{Key: "key.jump"}
+nbtComponent := &component.EntityNBT{
+    NBT:    component.NBT{Path: "Health", Plain: true},
+    Entity: "@s",
+}
 ```
 
 ### 🔄 Format Examples
 
-**Modern Format (1.21.5+):**
+**Atlas Sprite Object (1.21.9+):**
+
+```json
+{
+  "object": "atlas",
+  "atlas": "minecraft:blocks",
+  "sprite": "minecraft:item/diamond"
+}
+```
+
+**Player Head Object With Fallback (26.1+):**
+
+```json
+{
+  "fallback": {
+    "text": "jeb_"
+  },
+  "hat": true,
+  "object": "player",
+  "player": "jeb_"
+}
+```
+
+**Modern Hover Item Components (1.20.5+):**
+
+```json
+{
+  "text": "Hover",
+  "hover_event": {
+    "action": "show_item",
+    "id": "minecraft:diamond",
+    "count": 1,
+    "components": {
+      "minecraft:custom_name": {
+        "text": "Spark"
+      }
+    }
+  }
+}
+```
+
+**Modern Click/Hover Format (1.21.5+):**
 
 ```json
 {
@@ -226,8 +297,11 @@ customComponent := &component.Text{
 
 - **Legacy colors & formats**: Support for legacy color codes
 - **Minecraft 1.16+ hex colors**: Full hex color support (`#ff5555`)
+- **Minecraft 1.21.4+ shadow colors**: Packed integer and `[r, g, b, a]` float-array formats
 - **Hover events**: `show_text`, `show_item`, `show_entity` with all format variations
-- **Translations**: Full translation component support with arguments
+- **Modern item hover data**: Supports 1.20.5+ `components` next to legacy `tag`
+- **Object components**: 1.21.9+ atlas sprites and player heads, including 26.1 fallbacks
+- **Translations**: Full translation component support with arguments and fallback
 - **Cross-version compatibility**: Decode any format, encode in your preferred format
 - **Performance optimized**: Much faster than Go's standard JSON encoding
 - **Comprehensive testing**: Extensive test coverage for all versions and formats

--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ j := &codec.Json{
 | `JsonPre1_16`   | Before 1.16     | camelCase   | Universal "value" | Legacy + value    | Color downsampling          |
 | `JsonPre1_20_3` | 1.16 - 1.20.2   | camelCase   | Universal "value" | Legacy + contents | Hex colors                  |
 | `JsonPre1_21_5` | 1.20.3 - 1.21.4 | camelCase   | Universal "value" | Legacy + contents | Compact text, int UUIDs     |
-| `JsonModern`    | 1.21.5+         | snake_case  | Specific fields   | Inlined           | All modern features         |
-| `JsonUniversal` | Any             | snake_case  | Specific fields   | Inlined           | Decodes all, encodes modern |
+| `JsonModern`    | Modern clients  | snake_case  | Specific fields   | Inlined           | Shadow/object components, lossless item hover data |
+| `JsonUniversal` | Any             | snake_case  | Specific fields   | Inlined           | Decodes all, encodes modern losslessly |
 
 ### ⚙️ Advanced JSON Configuration Options
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ err := j.Marshal(&buf, component)
 | Selector | `selector`, `separator` | Supports component separator |
 | Keybind | `keybind` | Client-local keybind rendering |
 | NBT | `nbt`, `block`/`entity`/`storage`, `interpret`, `plain`, `separator` | Supports 26.1 `plain` |
-| Object | `object`, `atlas`/`sprite`, `player`, `hat`, `fallback` | Supports 1.21.9+ sprites/player heads and 26.1 fallback |
+| Object | `atlas`/`sprite`, `player`, `hat`, `fallback` | Supports 1.21.9+ sprites/player heads and 26.1 fallback |
 
 ### 🎛️ Version Configuration Examples
 
@@ -144,7 +144,7 @@ j := &codec.Json{
     EmitDefaultItemHoverQuantity:             true,  // Always emit count=1 (1.20.5+)
 
     // Advanced formatting modes
-    ShowItemHoverDataMode: codec.ShowItemHoverDataModeDataComponents, // Legacy NBT vs modern data components
+    ShowItemHoverDataMode: codec.ShowItemHoverDataModeEither, // Legacy NBT vs modern data components
     ShadowColorMode:       codec.ShadowColorEmitModeInteger,          // Shadow color format (1.21.4+)
 
     StdJson: true,
@@ -220,7 +220,6 @@ nbtComponent := &component.EntityNBT{
 
 ```json
 {
-  "object": "atlas",
   "atlas": "minecraft:blocks",
   "sprite": "minecraft:item/diamond"
 }
@@ -234,7 +233,6 @@ nbtComponent := &component.EntityNBT{
     "text": "jeb_"
   },
   "hat": true,
-  "object": "player",
   "player": "jeb_"
 }
 ```

--- a/minecraft/component/codec/json.go
+++ b/minecraft/component/codec/json.go
@@ -302,6 +302,20 @@ func (j *Json) encode(o obj, c Component) (err error) {
 		return j.encodeText(o, t)
 	case *Translation:
 		return j.encodeTranslation(o, t)
+	case *Score:
+		return j.encodeScore(o, t)
+	case *Selector:
+		return j.encodeSelector(o, t)
+	case *Keybind:
+		return j.encodeKeybind(o, t)
+	case *BlockNBT:
+		return j.encodeBlockNBT(o, t)
+	case *EntityNBT:
+		return j.encodeEntityNBT(o, t)
+	case *StorageNBT:
+		return j.encodeStorageNBT(o, t)
+	case *Object:
+		return j.encodeObject(o, t)
 	default:
 		return fmt.Errorf("codec.Json marshal: unsupported component type %T", c)
 	}
@@ -314,10 +328,44 @@ const (
 
 	translate     = "translate"
 	translateWith = "with"
+	fallback      = "fallback"
 
-	font      = "font"
-	color     = "color"
-	insertion = "insertion"
+	score          = "score"
+	scoreName      = "name"
+	scoreObjective = "objective"
+	scoreValue     = "value"
+
+	selector = "selector"
+	keybind  = "keybind"
+
+	nbtKey    = "nbt"
+	interpret = "interpret"
+	plain     = "plain"
+	block     = "block"
+	entity    = "entity"
+	storage   = "storage"
+	separator = "separator"
+
+	object = "object"
+
+	objectAtlas  = "atlas"
+	objectSprite = "sprite"
+	objectPlayer = "player"
+	objectHat    = "hat"
+
+	playerName       = "name"
+	playerId         = "id"
+	playerProperties = "properties"
+	playerTexture    = "texture"
+
+	profilePropertyName      = "name"
+	profilePropertyValue     = "value"
+	profilePropertySignature = "signature"
+
+	font        = "font"
+	color       = "color"
+	shadowColor = "shadow_color"
+	insertion   = "insertion"
 
 	// New format (1.21.5+): snake_case field names
 	clickEvent = "click_event"
@@ -354,9 +402,10 @@ const (
 	hoverEventText = "value" // Note: was "text" in 25w02a, changed back to "value" in 25w03a
 
 	// For show_item action (inlined from contents)
-	itemId    = "id"
-	itemCount = "count"
-	itemTag   = "tag"
+	itemId         = "id"
+	itemCount      = "count"
+	itemTag        = "tag"
+	itemComponents = "components"
 
 	// For show_entity action (inlined from contents, with field renames)
 	entityType = "id"   // renamed from "type" in 1.21.5+
@@ -380,7 +429,152 @@ func (j *Json) encodeTranslation(o obj, t *Translation) error {
 		return nil
 	}
 	o[translate] = t.Key
+	if t.Fallback != "" {
+		o[fallback] = t.Fallback
+	}
 	return j.encodeComponent(o, t, translateWith)
+}
+
+func (j *Json) encodeScore(o obj, s *Score) error {
+	if s == nil {
+		return nil
+	}
+	scoreObj := obj{
+		scoreName:      s.Name,
+		scoreObjective: s.Objective,
+	}
+	if s.Value != "" {
+		scoreObj[scoreValue] = s.Value
+	}
+	o[score] = scoreObj
+	return j.encodeComponent(o, s, extra)
+}
+
+func (j *Json) encodeSelector(o obj, s *Selector) error {
+	if s == nil {
+		return nil
+	}
+	o[selector] = s.Pattern
+	if s.Separator != nil {
+		separatorObj := obj{}
+		if err := j.encode(separatorObj, s.Separator); err != nil {
+			return err
+		}
+		o[separator] = separatorObj
+	}
+	return j.encodeComponent(o, s, extra)
+}
+
+func (j *Json) encodeKeybind(o obj, k *Keybind) error {
+	if k == nil {
+		return nil
+	}
+	o[keybind] = k.Key
+	return j.encodeComponent(o, k, extra)
+}
+
+func (j *Json) encodeBlockNBT(o obj, n *BlockNBT) error {
+	if n == nil {
+		return nil
+	}
+	o[block] = n.Block
+	return j.encodeNBT(o, &n.NBT)
+}
+
+func (j *Json) encodeEntityNBT(o obj, n *EntityNBT) error {
+	if n == nil {
+		return nil
+	}
+	o[entity] = n.Entity
+	return j.encodeNBT(o, &n.NBT)
+}
+
+func (j *Json) encodeStorageNBT(o obj, n *StorageNBT) error {
+	if n == nil {
+		return nil
+	}
+	if n.Storage != nil {
+		o[storage] = n.Storage.String()
+	}
+	return j.encodeNBT(o, &n.NBT)
+}
+
+func (j *Json) encodeNBT(o obj, n *NBT) error {
+	o[nbtKey] = n.Path
+	o[interpret] = n.Interpret
+	o[plain] = n.Plain
+	if n.Separator != nil {
+		separatorObj := obj{}
+		if err := j.encode(separatorObj, n.Separator); err != nil {
+			return err
+		}
+		o[separator] = separatorObj
+	}
+	return j.encodeComponent(o, n, extra)
+}
+
+func (j *Json) encodeObject(o obj, c *Object) error {
+	if c == nil {
+		return nil
+	}
+	if c.Fallback != nil {
+		fallbackObj := obj{}
+		if err := j.encode(fallbackObj, c.Fallback); err != nil {
+			return err
+		}
+		o[fallback] = fallbackObj
+	}
+	switch contents := c.Contents.(type) {
+	case *SpriteObjectContents:
+		o[object] = objectAtlas
+		if contents.Atlas != nil {
+			o[objectAtlas] = contents.Atlas.String()
+		}
+		if contents.Sprite != nil {
+			o[objectSprite] = contents.Sprite.String()
+		}
+	case *PlayerHeadObjectContents:
+		o[object] = objectPlayer
+		o[objectHat] = contents.Hat
+		o[objectPlayer] = j.encodePlayerProfile(contents.Profile)
+	default:
+		return fmt.Errorf("codec.Json marshal: unsupported object contents type %T", c.Contents)
+	}
+	return j.encodeComponent(o, c, extra)
+}
+
+func (j *Json) encodePlayerProfile(profile *PlayerProfile) interface{} {
+	if profile == nil {
+		return obj{}
+	}
+	if profile.Name != "" && profile.Id == uuid.Nil && len(profile.Properties) == 0 && profile.Texture == nil {
+		return profile.Name
+	}
+	o := obj{}
+	if profile.Name != "" {
+		o[playerName] = profile.Name
+	}
+	if profile.Id != uuid.Nil {
+		o[playerId] = profile.Id.String()
+	}
+	if len(profile.Properties) != 0 {
+		properties := make(arr, 0, len(profile.Properties))
+		for _, property := range profile.Properties {
+			propertyObj := obj{
+				profilePropertyName:  property.Name,
+				profilePropertyValue: property.Value,
+			}
+			if property.Signature != "" {
+				propertyObj[profilePropertySignature] = property.Signature
+			}
+			properties = append(properties, propertyObj)
+		}
+		o[playerProperties] = properties
+	}
+	if profile.Texture != nil {
+		o[playerTexture] = profile.Texture.String()
+	}
+	return o
 }
 
 func (j *Json) encodeComponent(o obj, c Component, childrenKey string) (err error) {
@@ -413,6 +607,9 @@ func (j *Json) encodeStyle(o obj, s *Style) error {
 	}
 	if s.Color != nil {
 		o[color] = j.encodeColor(s.Color)
+	}
+	if s.ShadowColor != nil && j.ShadowColorMode != ShadowColorEmitModeNone {
+		o[shadowColor] = j.encodeShadowColor(s.ShadowColor)
 	}
 	for name := range Decorations {
 		state := s.Decoration(name)
@@ -501,6 +698,23 @@ func (j *Json) encodeStyle(o obj, s *Style) error {
 	return nil
 }
 
+func (j *Json) encodeShadowColor(c *ShadowColor) interface{} {
+	if c == nil {
+		return nil
+	}
+	switch j.ShadowColorMode {
+	case ShadowColorEmitModeArray:
+		return arr{
+			float64((c.ARGB>>16)&0xff) / 255,
+			float64((c.ARGB>>8)&0xff) / 255,
+			float64(c.ARGB&0xff) / 255,
+			float64((c.ARGB>>24)&0xff) / 255,
+		}
+	default:
+		return int(int32(c.ARGB))
+	}
+}
+
 func (j *Json) encodeHoverEvent(o obj, event HoverEvent) error {
 	o[hoverEventAction] = event.Action().Name()
 
@@ -543,6 +757,9 @@ func (j *Json) encodeHoverEvent(o obj, event HoverEvent) error {
 				if t.NBT != nil {
 					itemObj[itemTag] = t.NBT.String()
 				}
+				if len(t.Components) != 0 {
+					itemObj[itemComponents] = obj(t.Components)
+				}
 				o[hoverEventContents] = itemObj
 				if !j.NoLegacyHover {
 					o[hoverEventValue] = itemObj
@@ -556,6 +773,9 @@ func (j *Json) encodeHoverEvent(o obj, event HoverEvent) error {
 				}
 				if t.NBT != nil {
 					o[itemTag] = t.NBT.String()
+				}
+				if len(t.Components) != 0 {
+					o[itemComponents] = obj(t.Components)
 				}
 			}
 		}
@@ -629,6 +849,10 @@ func (j *Json) decodeFromInterface(i interface{}) (Component, error) {
 		return j.decodeComponent(t)
 	case string:
 		return &Text{Content: t}, nil
+	case bool:
+		return &Text{Content: strconv.FormatBool(t)}, nil
+	case float64:
+		return &Text{Content: strconv.FormatFloat(t, 'f', -1, 64)}, nil
 	case []interface{}:
 		return j.decodeFromInterfaceSlice(t)
 	default:
@@ -660,6 +884,10 @@ func (j *Json) decodeComponent(o obj) (c Component, err error) {
 		c = &Text{Content: fmt.Sprint(o[text])}
 	} else if o.Has(translate) {
 		k := fmt.Sprint(o[translate])
+		f := ""
+		if o.Has(fallback) {
+			f = fmt.Sprint(o[fallback])
+		}
 		if o.Has(translateWith) {
 			with, ok := o[translateWith].([]interface{})
 			if !ok {
@@ -674,11 +902,34 @@ func (j *Json) decodeComponent(o obj) (c Component, err error) {
 				args = append(args, a)
 			}
 			c = &Translation{
-				Key:  k,
-				With: args,
+				Key:      k,
+				Fallback: f,
+				With:     args,
 			}
 		} else {
-			c = &Translation{Key: k}
+			c = &Translation{Key: k, Fallback: f}
+		}
+	} else if o.Has(score) {
+		c, err = j.decodeScore(o)
+		if err != nil {
+			return nil, err
+		}
+	} else if o.Has(selector) {
+		c, err = j.decodeSelector(o)
+		if err != nil {
+			return nil, err
+		}
+	} else if o.Has(keybind) {
+		c = &Keybind{Key: fmt.Sprint(o[keybind])}
+	} else if o.Has(nbtKey) {
+		c, err = j.decodeNBT(o)
+		if err != nil {
+			return nil, err
+		}
+	} else if o.Has(object) || o.Has(objectSprite) || o.Has(objectPlayer) {
+		c, err = j.decodeObject(o)
+		if err != nil {
+			return nil, err
 		}
 	} else {
 		c = &Text{}
@@ -708,6 +959,224 @@ func (j *Json) decodeComponent(o obj) (c Component, err error) {
 	return c, nil
 }
 
+func (j *Json) decodeScore(o obj) (*Score, error) {
+	scoreObj, ok := o[score].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf(`value of key %q is not a json object, but %T`, score, o[score])
+	}
+	s := &Score{
+		Name:      fmt.Sprint(scoreObj[scoreName]),
+		Objective: fmt.Sprint(scoreObj[scoreObjective]),
+	}
+	if v, ok := scoreObj[scoreValue]; ok {
+		s.Value = fmt.Sprint(v)
+	}
+	return s, nil
+}
+
+func (j *Json) decodeSelector(o obj) (*Selector, error) {
+	s := &Selector{Pattern: fmt.Sprint(o[selector])}
+	if o.Has(separator) {
+		separator, err := j.decodeFromInterface(o[separator])
+		if err != nil {
+			return nil, fmt.Errorf(`error decoding selector separator: %v`, err)
+		}
+		s.Separator = separator
+	}
+	return s, nil
+}
+
+func (j *Json) decodeNBT(o obj) (Component, error) {
+	base := NBT{
+		Path:      fmt.Sprint(o[nbtKey]),
+		Interpret: boolValue(o[interpret]),
+		Plain:     boolValue(o[plain]),
+	}
+	if base.Interpret && base.Plain {
+		return nil, errors.New("nbt component cannot have both interpret and plain set to true")
+	}
+	if o.Has(separator) {
+		separator, err := j.decodeFromInterface(o[separator])
+		if err != nil {
+			return nil, fmt.Errorf(`error decoding nbt separator: %v`, err)
+		}
+		base.Separator = separator
+	}
+	if o.Has(block) {
+		return &BlockNBT{NBT: base, Block: fmt.Sprint(o[block])}, nil
+	}
+	if o.Has(entity) {
+		return &EntityNBT{NBT: base, Entity: fmt.Sprint(o[entity])}, nil
+	}
+	if o.Has(storage) {
+		storage, err := j.decodeNamespacedKey(o[storage])
+		if err != nil {
+			return nil, fmt.Errorf(`error decoding nbt storage: %v`, err)
+		}
+		return &StorageNBT{NBT: base, Storage: storage}, nil
+	}
+	return nil, errors.New("nbt component requires one of block, entity, or storage")
+}
+
+func (j *Json) decodeObject(o obj) (*Object, error) {
+	objectType := o.String(object)
+	if objectType == "" {
+		switch {
+		case o.Has(objectSprite):
+			objectType = objectAtlas
+		case o.Has(objectPlayer):
+			objectType = objectPlayer
+		}
+	}
+
+	c := &Object{}
+	if o.Has(fallback) {
+		fallback, err := j.decodeFromInterface(o[fallback])
+		if err != nil {
+			return nil, fmt.Errorf(`error decoding object component fallback: %v`, err)
+		}
+		c.Fallback = fallback
+	}
+
+	switch objectType {
+	case objectAtlas:
+		if !o.Has(objectSprite) {
+			return nil, fmt.Errorf(`object component of type %q misses key %q`, objectAtlas, objectSprite)
+		}
+		atlas := DefaultSpriteAtlas
+		if o.Has(objectAtlas) {
+			k, err := j.decodeNamespacedKey(o[objectAtlas])
+			if err != nil {
+				return nil, fmt.Errorf(`error decoding object component atlas: %v`, err)
+			}
+			atlas = k
+		}
+		sprite, err := j.decodeNamespacedKey(o[objectSprite])
+		if err != nil {
+			return nil, fmt.Errorf(`error decoding object component sprite: %v`, err)
+		}
+		c.Contents = &SpriteObjectContents{
+			Atlas:  atlas,
+			Sprite: sprite,
+		}
+	case objectPlayer:
+		profile, err := j.decodePlayerProfile(o[objectPlayer])
+		if err != nil {
+			return nil, err
+		}
+		hat := true
+		if o.Has(objectHat) {
+			v, ok := o[objectHat].(bool)
+			if !ok {
+				return nil, fmt.Errorf(`object component's value of key %q is not a bool, but %T`, objectHat, o[objectHat])
+			}
+			hat = v
+		}
+		c.Contents = &PlayerHeadObjectContents{
+			Profile: profile,
+			Hat:     hat,
+		}
+	default:
+		return nil, fmt.Errorf("unsupported object component type %q", objectType)
+	}
+
+	return c, nil
+}
+
+func (j *Json) decodePlayerProfile(v interface{}) (*PlayerProfile, error) {
+	switch t := v.(type) {
+	case string:
+		return &PlayerProfile{Name: t}, nil
+	case map[string]interface{}:
+		o := obj(t)
+		profile := &PlayerProfile{}
+		if o.Has(playerName) {
+			name, ok := o[playerName].(string)
+			if !ok {
+				return nil, fmt.Errorf(`player profile's value of key %q is not a string, but %T`, playerName, o[playerName])
+			}
+			profile.Name = name
+		}
+		if o.Has(playerId) {
+			id, err := j.decodeUUID(o[playerId])
+			if err != nil {
+				return nil, fmt.Errorf(`error decoding player profile id: %v`, err)
+			}
+			profile.Id = id
+		}
+		if o.Has(playerProperties) {
+			properties, err := j.decodeProfileProperties(o[playerProperties])
+			if err != nil {
+				return nil, err
+			}
+			profile.Properties = properties
+		}
+		if o.Has(playerTexture) {
+			texture, err := j.decodeNamespacedKey(o[playerTexture])
+			if err != nil {
+				return nil, fmt.Errorf(`error decoding player profile texture: %v`, err)
+			}
+			profile.Texture = texture
+		}
+		return profile, nil
+	default:
+		return nil, fmt.Errorf(`object component's value of key %q is not a string or object, but %T`, objectPlayer, v)
+	}
+}
+
+func (j *Json) decodeProfileProperties(v interface{}) ([]ProfileProperty, error) {
+	switch t := v.(type) {
+	case []interface{}:
+		properties := make([]ProfileProperty, 0, len(t))
+		for _, entry := range t {
+			propertyObj, ok := entry.(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf(`player profile property is not an object, but %T`, entry)
+			}
+			property, err := j.decodeProfileProperty(propertyObj)
+			if err != nil {
+				return nil, err
+			}
+			properties = append(properties, property)
+		}
+		return properties, nil
+	case map[string]interface{}:
+		properties := make([]ProfileProperty, 0, len(t))
+		for name, value := range t {
+			propertyValue, ok := value.(string)
+			if !ok {
+				return nil, fmt.Errorf(`player profile property %q is not a string, but %T`, name, value)
+			}
+			properties = append(properties, ProfileProperty{Name: name, Value: propertyValue})
+		}
+		return properties, nil
+	default:
+		return nil, fmt.Errorf(`player profile's value of key %q is not an array or object, but %T`, playerProperties, v)
+	}
+}
+
+func (j *Json) decodeProfileProperty(o obj) (ProfileProperty, error) {
+	property := ProfileProperty{}
+	name, ok := o[profilePropertyName].(string)
+	if !ok {
+		return property, fmt.Errorf(`player profile property misses string key %q`, profilePropertyName)
+	}
+	value, ok := o[profilePropertyValue].(string)
+	if !ok {
+		return property, fmt.Errorf(`player profile property misses string key %q`, profilePropertyValue)
+	}
+	property.Name = name
+	property.Value = value
+	if o.Has(profilePropertySignature) {
+		signature, ok := o[profilePropertySignature].(string)
+		if !ok {
+			return property, fmt.Errorf(`player profile property's value of key %q is not a string, but %T`, profilePropertySignature, o[profilePropertySignature])
+		}
+		property.Signature = signature
+	}
+	return property, nil
+}
+
 func (j *Json) decodeStyle(o obj) (s *Style, err error) {
 	s = &Style{}
 	if o.Has(font) {
@@ -728,6 +1197,13 @@ func (j *Json) decodeStyle(o obj) (s *Style, err error) {
 			// Setting a decoration from a color is, unfortunately, something we need to support.
 			s.SetDecoration(*dec, True)
 		}
+	}
+	if o.Has(shadowColor) {
+		c, err := j.decodeShadowColor(o[shadowColor])
+		if err != nil {
+			return nil, fmt.Errorf(`error decoding value of %q key: %v`, shadowColor, err)
+		}
+		s.ShadowColor = c
 	}
 	for dec := range Decorations {
 		if o.Has(string(dec)) {
@@ -801,6 +1277,36 @@ func (j *Json) decodeStyle(o obj) (s *Style, err error) {
 	return s, nil
 }
 
+func (j *Json) decodeShadowColor(v interface{}) (*ShadowColor, error) {
+	switch t := v.(type) {
+	case float64:
+		return &ShadowColor{ARGB: uint32(int32(t))}, nil
+	case []interface{}:
+		if len(t) != 4 {
+			return nil, fmt.Errorf("shadow color array must have 4 entries, got %d", len(t))
+		}
+		r, ok := normalizedColorByte(t[0])
+		if !ok {
+			return nil, fmt.Errorf("shadow color red component is not a number")
+		}
+		g, ok := normalizedColorByte(t[1])
+		if !ok {
+			return nil, fmt.Errorf("shadow color green component is not a number")
+		}
+		b, ok := normalizedColorByte(t[2])
+		if !ok {
+			return nil, fmt.Errorf("shadow color blue component is not a number")
+		}
+		a, ok := normalizedColorByte(t[3])
+		if !ok {
+			return nil, fmt.Errorf("shadow color alpha component is not a number")
+		}
+		return &ShadowColor{ARGB: uint32(a)<<24 | uint32(r)<<16 | uint32(g)<<8 | uint32(b)}, nil
+	default:
+		return nil, fmt.Errorf("must be a number or 4-element array, but %T", v)
+	}
+}
+
 // may return nil,nil in case object has missing/invalid keys to decode a HoverEvent or Readable() == false
 func (j *Json) decodeHoverEvent(o obj) (h HoverEvent, err error) {
 	if !o.Has(hoverEventAction) {
@@ -858,6 +1364,14 @@ func (j *Json) decodeHoverEvent(o obj) (h HoverEvent, err error) {
 						itemTag, o[itemTag])
 				}
 				h.NBT = nbt.NewBinaryTagHolder(s)
+			}
+			if o.Has(itemComponents) {
+				components, ok := o[itemComponents].(map[string]interface{})
+				if !ok {
+					return nil, fmt.Errorf(`show item hover event's value of key %q is not an object, but %T`,
+						itemComponents, o[itemComponents])
+				}
+				h.Components = components
 			}
 			value = &h
 		} else if o.Has(hoverEventContents) {
@@ -985,6 +1499,14 @@ func (j *Json) decodeHoverEventContents(v interface{}, action HoverAction) (valu
 					itemTag, o[itemTag])
 			}
 			h.NBT = nbt.NewBinaryTagHolder(s)
+		}
+		if o.Has(itemComponents) {
+			components, ok := o[itemComponents].(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf(`show entity hover event's value of key %q is not an object, but %T`,
+					itemComponents, o[itemComponents])
+			}
+			h.Components = components
 		}
 		return &h, nil
 	case equalFold(ShowEntityAction, action):
@@ -1151,6 +1673,17 @@ func (j *Json) decodeKey(i interface{}) (key.Key, error) {
 	return nil, errors.New("must be as string")
 }
 
+func (j *Json) decodeNamespacedKey(i interface{}) (key.Key, error) {
+	s, ok := i.(string)
+	if !ok {
+		return nil, errors.New("must be as string")
+	}
+	if !strings.Contains(s, ":") {
+		s = key.MinecraftNamespace + ":" + s
+	}
+	return key.ParseValid(s)
+}
+
 func (j *Json) decodeUUID(i interface{}) (uuid.UUID, error) {
 	if s, ok := i.(string); ok {
 		return uuid.Parse(s)
@@ -1184,6 +1717,25 @@ func (o obj) String(key string) string {
 func (o obj) Has(key string) bool {
 	_, ok := o[key]
 	return ok
+}
+
+func boolValue(v interface{}) bool {
+	b, _ := v.(bool)
+	return b
+}
+
+func normalizedColorByte(v interface{}) (uint8, bool) {
+	f, ok := v.(float64)
+	if !ok {
+		return 0, false
+	}
+	if f < 0 {
+		f = 0
+	}
+	if f > 1 {
+		f = 1
+	}
+	return uint8(f*255 + 0.5), true
 }
 
 func (o obj) MarshalJSONObject(enc *gojay.Encoder) {

--- a/minecraft/component/codec/json.go
+++ b/minecraft/component/codec/json.go
@@ -1,6 +1,7 @@
 package codec
 
 import (
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -253,6 +254,16 @@ var (
 
 // Marshal writes the json encoded Component to the Writer.
 func (j *Json) Marshal(wr io.Writer, c Component) (err error) {
+	if s, ok := j.compactTextContent(c); ok {
+		var data []byte
+		data, err = json.Marshal(s)
+		if err != nil {
+			return err
+		}
+		_, err = wr.Write(data)
+		return err
+	}
+
 	o := obj{}
 	if err = j.encode(o, c); err != nil {
 		return err
@@ -584,6 +595,11 @@ func (j *Json) encodeComponent(o obj, c Component, childrenKey string) (err erro
 	}
 	var children arr
 	for _, child := range c.Children() {
+		if childText, ok := j.compactTextContent(child); ok {
+			children = append(children, childText)
+			continue
+		}
+
 		childObj := obj{}
 		if err = j.encode(childObj, child); err != nil {
 			return err
@@ -594,6 +610,20 @@ func (j *Json) encodeComponent(o obj, c Component, childrenKey string) (err erro
 		o[childrenKey] = children
 	}
 	return nil
+}
+
+func (j *Json) compactTextContent(c Component) (string, bool) {
+	if !j.EmitCompactTextComponent {
+		return "", false
+	}
+	t, ok := c.(*Text)
+	if !ok || len(t.Extra) != 0 {
+		return "", false
+	}
+	if !t.S.IsZero() {
+		return "", false
+	}
+	return t.Content, true
 }
 
 func (j *Json) encodeStyle(o obj, s *Style) error {
@@ -619,6 +649,10 @@ func (j *Json) encodeStyle(o obj, s *Style) error {
 		o[insertion] = *s.Insertion
 	}
 	if s.ClickEvent != nil {
+		if err := j.validateClickEvent(s.ClickEvent.Action()); err != nil {
+			return err
+		}
+
 		clickEventKey := clickEvent
 		if j.UseLegacyFieldNames {
 			clickEventKey = clickEventLegacy
@@ -681,6 +715,10 @@ func (j *Json) encodeStyle(o obj, s *Style) error {
 		o[clickEventKey] = clickEventObj
 	}
 	if s.HoverEvent != nil {
+		if err := j.validateHoverEvent(s.HoverEvent.Action()); err != nil {
+			return err
+		}
+
 		eventObj := obj{}
 		if err := j.encodeHoverEvent(eventObj, s.HoverEvent); err != nil {
 			return err
@@ -692,6 +730,28 @@ func (j *Json) encodeStyle(o obj, s *Style) error {
 			}
 			o[hoverEventKey] = eventObj
 		}
+	}
+	return nil
+}
+
+func (j *Json) validateClickEvent(action ClickAction) error {
+	if !j.ValidateStrictEvents {
+		return nil
+	}
+	known, ok := ClickActions[action.Name()]
+	if !ok || !known.Readable() {
+		return fmt.Errorf("%w: %s", errUnsupportedClickEventAction, action.Name())
+	}
+	return nil
+}
+
+func (j *Json) validateHoverEvent(action HoverAction) error {
+	if !j.ValidateStrictEvents {
+		return nil
+	}
+	known, ok := HoverActions[action.Name()]
+	if !ok || !known.Readable() {
+		return fmt.Errorf("%w: %s", errUnsupportedHoverEventAction, action.Name())
 	}
 	return nil
 }
@@ -758,7 +818,7 @@ func (j *Json) encodeHoverEvent(o obj, event HoverEvent) error {
 					}
 				}
 				if j.shouldEmitShowItemComponents(t) {
-					itemObj[itemComponents] = obj(t.Components)
+					itemObj[itemComponents] = normalizeJsonValue(t.Components)
 				}
 				o[hoverEventContents] = itemObj
 				if !j.NoLegacyHover {
@@ -777,7 +837,7 @@ func (j *Json) encodeHoverEvent(o obj, event HoverEvent) error {
 					}
 				}
 				if j.shouldEmitShowItemComponents(t) {
-					o[itemComponents] = obj(t.Components)
+					o[itemComponents] = normalizeJsonValue(t.Components)
 				}
 			}
 		}
@@ -785,9 +845,15 @@ func (j *Json) encodeHoverEvent(o obj, event HoverEvent) error {
 	case "show_entity":
 		switch t := event.Value().(type) {
 		case *ShowEntityHoverType:
-			nameObj := obj{}
-			if err := j.encode(nameObj, t.Name); err != nil {
-				return err
+			var nameValue interface{}
+			if text, ok := j.compactTextContent(t.Name); ok {
+				nameValue = text
+			} else {
+				nameObj := obj{}
+				if err := j.encode(nameObj, t.Name); err != nil {
+					return err
+				}
+				nameValue = nameObj
 			}
 
 			if j.UseLegacyHoverEventStructure {
@@ -796,13 +862,13 @@ func (j *Json) encodeHoverEvent(o obj, event HoverEvent) error {
 				if j.EmitHoverShowEntityKeyAsTypeAndUuidAsId {
 					// Use legacy field names: "type" and "id"
 					entityObj[entityTypeLegacy] = t.Type.String()
-					entityObj[entityIdLegacy] = t.Id.String()
+					entityObj[entityIdLegacy] = j.encodeUUID(t.Id)
 				} else {
 					// Use modern field names: "id" and "uuid"
 					entityObj[entityType] = t.Type.String()
-					entityObj[entityUuid] = t.Id.String()
+					entityObj[entityUuid] = j.encodeUUID(t.Id)
 				}
-				entityObj[entityName] = nameObj
+				entityObj[entityName] = nameValue
 				o[hoverEventContents] = entityObj
 				if !j.NoLegacyHover {
 					o[hoverEventValue] = entityObj
@@ -812,18 +878,49 @@ func (j *Json) encodeHoverEvent(o obj, event HoverEvent) error {
 				if j.EmitHoverShowEntityKeyAsTypeAndUuidAsId {
 					// Use legacy field names: "type" and "id"
 					o[entityTypeLegacy] = t.Type.String()
-					o[entityIdLegacy] = t.Id.String()
+					o[entityIdLegacy] = j.encodeUUID(t.Id)
 				} else {
 					// Use modern field names: "id" and "uuid"
 					o[entityType] = t.Type.String()
-					o[entityUuid] = t.Id.String()
+					o[entityUuid] = j.encodeUUID(t.Id)
 				}
-				o[entityName] = nameObj
+				o[entityName] = nameValue
 			}
 		}
 	}
 
 	return nil
+}
+
+func normalizeJsonValue(v interface{}) interface{} {
+	switch t := v.(type) {
+	case map[string]interface{}:
+		o := obj{}
+		for k, value := range t {
+			o[k] = normalizeJsonValue(value)
+		}
+		return o
+	case []interface{}:
+		a := arr{}
+		for _, value := range t {
+			a = append(a, normalizeJsonValue(value))
+		}
+		return a
+	default:
+		return v
+	}
+}
+
+func (j *Json) encodeUUID(id uuid.UUID) interface{} {
+	if !j.EmitHoverShowEntityIdAsIntArray {
+		return id.String()
+	}
+	return arr{
+		int(int32(binary.BigEndian.Uint32(id[0:4]))),
+		int(int32(binary.BigEndian.Uint32(id[4:8]))),
+		int(int32(binary.BigEndian.Uint32(id[8:12]))),
+		int(int32(binary.BigEndian.Uint32(id[12:16]))),
+	}
 }
 
 func (j *Json) shouldEmitShowItemNBT(item *ShowItemHoverType) bool {
@@ -1277,7 +1374,10 @@ func (j *Json) decodeStyle(o obj) (s *Style, err error) {
 		if !ok {
 			return nil, fmt.Errorf(`value of key %q is not a json object, but %T`, fieldName, o[fieldName])
 		}
-		s.ClickEvent = j.decodeClickEvent(obj)
+		s.ClickEvent, err = j.decodeClickEvent(obj)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Support both new (hover_event) and legacy (hoverEvent) field names for maximum compatibility
@@ -1394,6 +1494,9 @@ func (j *Json) decodeHoverEvent(o obj) (h HoverEvent, err error) {
 	}
 	hoverAction, ok := HoverActions[action]
 	if !ok || !hoverAction.Readable() {
+		if j.ValidateStrictEvents {
+			return nil, fmt.Errorf("%w: %s", errUnsupportedHoverEventAction, action)
+		}
 		return nil, nil
 	}
 
@@ -1516,7 +1619,10 @@ func (j *Json) decodeHoverEvent(o obj) (h HoverEvent, err error) {
 	return NewHoverEvent(hoverAction, value), nil
 }
 
-var errUnsupportedHoverEventAction = errors.New("unsupported hover event action")
+var (
+	errUnsupportedHoverEventAction = errors.New("unsupported hover event action")
+	errUnsupportedClickEventAction = errors.New("unsupported click event action")
+)
 
 func (j *Json) decodeHoverEventContents(v interface{}, action HoverAction) (value interface{}, err error) {
 	var o obj
@@ -1625,17 +1731,20 @@ func (j *Json) decodeHoverEventContents(v interface{}, action HoverAction) (valu
 }
 
 // may return nil in case object has missing/invalid keys to decode a ClickEvent or Readable() == false
-func (j *Json) decodeClickEvent(o obj) ClickEvent {
+func (j *Json) decodeClickEvent(o obj) (ClickEvent, error) {
 	if !o.Has(clickEventAction) {
-		return nil
+		return nil, nil
 	}
 	action, ok := o[clickEventAction].(string)
 	if !ok {
-		return nil
+		return nil, nil
 	}
 	clickAction, ok := ClickActions[action]
 	if !ok || !clickAction.Readable() {
-		return nil
+		if j.ValidateStrictEvents {
+			return nil, fmt.Errorf("%w: %s", errUnsupportedClickEventAction, action)
+		}
+		return nil, nil
 	}
 
 	// Try to extract value using different field names based on action and version
@@ -1710,10 +1819,10 @@ func (j *Json) decodeClickEvent(o obj) ClickEvent {
 	}
 
 	if value == "" {
-		return nil
+		return nil, nil
 	}
 
-	return NewClickEvent(clickAction, value)
+	return NewClickEvent(clickAction, value), nil
 }
 
 func (j *Json) decodeColor(i interface{}) (c col.Color, dec *Decoration, reset bool, err error) {
@@ -1764,6 +1873,20 @@ func (j *Json) decodeUUID(i interface{}) (uuid.UUID, error) {
 	if s, ok := i.(string); ok {
 		return uuid.Parse(s)
 	}
+	if a, ok := i.([]interface{}); ok {
+		if len(a) != 4 {
+			return [16]byte{}, fmt.Errorf("uuid int array must have 4 entries, got %d", len(a))
+		}
+		var id uuid.UUID
+		for idx, value := range a {
+			part, ok := int32JsonNumber(value)
+			if !ok {
+				return [16]byte{}, fmt.Errorf("uuid int array entry %d is not an int32 number", idx)
+			}
+			binary.BigEndian.PutUint32(id[idx*4:(idx+1)*4], uint32(part))
+		}
+		return id, nil
+	}
 	return [16]byte{}, errors.New("must be as string")
 }
 
@@ -1798,6 +1921,14 @@ func (o obj) Has(key string) bool {
 func boolValue(v interface{}) bool {
 	b, _ := v.(bool)
 	return b
+}
+
+func int32JsonNumber(v interface{}) (int32, bool) {
+	f, ok := v.(float64)
+	if !ok || f < -2147483648 || f > 2147483647 || f != float64(int64(f)) {
+		return 0, false
+	}
+	return int32(f), true
 }
 
 func normalizedColorByte(v interface{}) (uint8, bool) {

--- a/minecraft/component/codec/json.go
+++ b/minecraft/component/codec/json.go
@@ -226,7 +226,7 @@ var (
 		EmitHoverShowEntityKeyAsTypeAndUuidAsId: false, // Modern field names
 		ValidateStrictEvents:                    true,  // Strict validation
 		EmitDefaultItemHoverQuantity:            true,  // Emit count=1
-		ShowItemHoverDataMode:                   ShowItemHoverDataModeDataComponents,
+		ShowItemHoverDataMode:                   ShowItemHoverDataModeEither,
 		ShadowColorMode:                         ShadowColorEmitModeInteger,
 		StdJson:                                 true,
 	}
@@ -245,7 +245,7 @@ var (
 		EmitHoverShowEntityKeyAsTypeAndUuidAsId: false, // Modern field names
 		ValidateStrictEvents:                    true,  // Modern validation
 		EmitDefaultItemHoverQuantity:            true,  // Modern quantity emission
-		ShowItemHoverDataMode:                   ShowItemHoverDataModeDataComponents,
+		ShowItemHoverDataMode:                   ShowItemHoverDataModeEither,
 		ShadowColorMode:                         ShadowColorEmitModeInteger,
 		StdJson:                                 true,
 	}
@@ -526,7 +526,6 @@ func (j *Json) encodeObject(o obj, c *Object) error {
 	}
 	switch contents := c.Contents.(type) {
 	case *SpriteObjectContents:
-		o[object] = objectAtlas
 		if contents.Atlas != nil {
 			o[objectAtlas] = contents.Atlas.String()
 		}
@@ -534,7 +533,6 @@ func (j *Json) encodeObject(o obj, c *Object) error {
 			o[objectSprite] = contents.Sprite.String()
 		}
 	case *PlayerHeadObjectContents:
-		o[object] = objectPlayer
 		o[objectHat] = contents.Hat
 		o[objectPlayer] = j.encodePlayerProfile(contents.Profile)
 	default:
@@ -721,7 +719,7 @@ func (j *Json) encodeHoverEvent(o obj, event HoverEvent) error {
 	switch event.Action().Name() {
 	case "show_text":
 		switch t := event.Value().(type) {
-		case *Text:
+		case Component:
 			if j.UseLegacyHoverEventStructure {
 				// Legacy structure: use "contents" field
 				textObj := obj{}
@@ -755,9 +753,11 @@ func (j *Json) encodeHoverEvent(o obj, event HoverEvent) error {
 					itemObj[itemCount] = t.Count
 				}
 				if t.NBT != nil {
-					itemObj[itemTag] = t.NBT.String()
+					if j.shouldEmitShowItemNBT(t) {
+						itemObj[itemTag] = t.NBT.String()
+					}
 				}
-				if len(t.Components) != 0 {
+				if j.shouldEmitShowItemComponents(t) {
 					itemObj[itemComponents] = obj(t.Components)
 				}
 				o[hoverEventContents] = itemObj
@@ -772,9 +772,11 @@ func (j *Json) encodeHoverEvent(o obj, event HoverEvent) error {
 					o[itemCount] = t.Count
 				}
 				if t.NBT != nil {
-					o[itemTag] = t.NBT.String()
+					if j.shouldEmitShowItemNBT(t) {
+						o[itemTag] = t.NBT.String()
+					}
 				}
-				if len(t.Components) != 0 {
+				if j.shouldEmitShowItemComponents(t) {
 					o[itemComponents] = obj(t.Components)
 				}
 			}
@@ -822,6 +824,32 @@ func (j *Json) encodeHoverEvent(o obj, event HoverEvent) error {
 	}
 
 	return nil
+}
+
+func (j *Json) shouldEmitShowItemNBT(item *ShowItemHoverType) bool {
+	if item == nil || item.NBT == nil {
+		return false
+	}
+	switch j.ShowItemHoverDataMode {
+	case ShowItemHoverDataModeDataComponents:
+		return false
+	case ShowItemHoverDataModeEither:
+		return len(item.Components) == 0
+	default:
+		return true
+	}
+}
+
+func (j *Json) shouldEmitShowItemComponents(item *ShowItemHoverType) bool {
+	if item == nil || len(item.Components) == 0 {
+		return false
+	}
+	switch j.ShowItemHoverDataMode {
+	case ShowItemHoverDataModeLegacyNBT:
+		return false
+	default:
+		return true
+	}
 }
 
 func (j *Json) encodeColor(c col.Color) (s string) {
@@ -1143,11 +1171,20 @@ func (j *Json) decodeProfileProperties(v interface{}) ([]ProfileProperty, error)
 	case map[string]interface{}:
 		properties := make([]ProfileProperty, 0, len(t))
 		for name, value := range t {
-			propertyValue, ok := value.(string)
-			if !ok {
-				return nil, fmt.Errorf(`player profile property %q is not a string, but %T`, name, value)
+			switch values := value.(type) {
+			case []interface{}:
+				for _, entry := range values {
+					propertyValue, ok := entry.(string)
+					if !ok {
+						return nil, fmt.Errorf(`player profile property %q entry is not a string, but %T`, name, entry)
+					}
+					properties = append(properties, ProfileProperty{Name: name, Value: propertyValue})
+				}
+			case string:
+				properties = append(properties, ProfileProperty{Name: name, Value: values})
+			default:
+				return nil, fmt.Errorf(`player profile property %q is not a string or string array, but %T`, name, value)
 			}
-			properties = append(properties, ProfileProperty{Name: name, Value: propertyValue})
 		}
 		return properties, nil
 	default:

--- a/minecraft/component/codec/json.go
+++ b/minecraft/component/codec/json.go
@@ -1244,17 +1244,9 @@ func (j *Json) decodeStyle(o obj) (s *Style, err error) {
 	}
 	for dec := range Decorations {
 		if o.Has(string(dec)) {
-			var b bool
-			switch v := o[string(dec)].(type) {
-			case string:
-				b, err = strconv.ParseBool(v)
-				if err != nil {
-					return nil, fmt.Errorf(`value of key %q is not a bool, but %T: %s`, dec, o[string(dec)], v)
-				}
-			case bool:
-				b = v
-			default:
-				return nil, fmt.Errorf(`value of key %q is not a bool, but %T`, dec, o[string(dec)])
+			b, ok := decodeBoolLike(o[string(dec)])
+			if !ok {
+				return nil, fmt.Errorf(`value of key %q is not a bool, but %T: %v`, dec, o[string(dec)], o[string(dec)])
 			}
 			s.SetDecoration(dec, StateByBool(b))
 		}
@@ -1312,6 +1304,53 @@ func (j *Json) decodeStyle(o obj) (s *Style, err error) {
 		}
 	}
 	return s, nil
+}
+
+func decodeBoolLike(v interface{}) (bool, bool) {
+	switch b := v.(type) {
+	case bool:
+		return b, true
+	case string:
+		s := strings.TrimSpace(b)
+		if p, err := strconv.ParseBool(s); err == nil {
+			return p, true
+		}
+		s = strings.TrimSuffix(strings.TrimSuffix(s, "b"), "B")
+		switch s {
+		case "1":
+			return true, true
+		case "0":
+			return false, true
+		default:
+			return false, false
+		}
+	case int:
+		return b == 1, b == 0 || b == 1
+	case int8:
+		return b == 1, b == 0 || b == 1
+	case int16:
+		return b == 1, b == 0 || b == 1
+	case int32:
+		return b == 1, b == 0 || b == 1
+	case int64:
+		return b == 1, b == 0 || b == 1
+	case uint:
+		return b == 1, b == 0 || b == 1
+	case uint8:
+		return b == 1, b == 0 || b == 1
+	case uint16:
+		return b == 1, b == 0 || b == 1
+	case uint32:
+		return b == 1, b == 0 || b == 1
+	case uint64:
+		return b == 1, b == 0 || b == 1
+	case float32:
+		return b == 1, b == 0 || b == 1
+	case float64:
+		return b == 1, b == 0 || b == 1
+	default:
+		return false, false
+	}
 }
 
 func (j *Json) decodeShadowColor(v interface{}) (*ShadowColor, error) {

--- a/minecraft/component/codec/json.go
+++ b/minecraft/component/codec/json.go
@@ -211,9 +211,9 @@ var (
 		StdJson:                                 true,
 	}
 
-	// JsonModern is optimized for Minecraft clients 1.21.5+.
+	// JsonModern is optimized for modern Minecraft clients.
 	// Features: snake_case field names, specific click fields, inlined hover structure,
-	// all modern features enabled.
+	// shadow colors, modern object components when used, and lossless show_item data.
 	JsonModern = &Json{
 		UseLegacyFieldNames:                     false, // snake_case field names
 		UseLegacyClickEventStructure:            false, // Specific fields (url, path, command, etc.)
@@ -232,7 +232,7 @@ var (
 	}
 
 	// JsonUniversal provides maximum compatibility - can decode any format
-	// but encodes in modern format. Recommended for most use cases.
+	// but encodes in modern format with lossless show_item data. Recommended for most use cases.
 	JsonUniversal = &Json{
 		UseLegacyFieldNames:                     false, // Encode in modern format
 		UseLegacyClickEventStructure:            false, // Encode in modern format

--- a/minecraft/component/codec/json.go
+++ b/minecraft/component/codec/json.go
@@ -1613,6 +1613,9 @@ func (j *Json) decodeHoverEvent(o obj) (h HoverEvent, err error) {
 		return nil, err
 	}
 	if value == nil {
+		if j.ValidateStrictEvents {
+			return nil, fmt.Errorf("missing value for hover event action %q", action)
+		}
 		return nil, nil
 	}
 
@@ -1819,6 +1822,9 @@ func (j *Json) decodeClickEvent(o obj) (ClickEvent, error) {
 	}
 
 	if value == "" {
+		if j.ValidateStrictEvents {
+			return nil, fmt.Errorf("missing value for click event action %q", action)
+		}
 		return nil, nil
 	}
 

--- a/minecraft/component/codec/json_test.go
+++ b/minecraft/component/codec/json_test.go
@@ -123,6 +123,146 @@ func TestJson_translation(t *testing.T) {
 	require.Equal(t, tr, tr2)
 }
 
+func TestJson_TranslationFallback(t *testing.T) {
+	tr := &Translation{
+		Key:      "sample.missing",
+		Fallback: "Fallback text",
+	}
+	s := new(strings.Builder)
+	require.NoError(t, j1215Plus.Marshal(s, tr))
+	require.Equal(t, `{"fallback":"Fallback text","translate":"sample.missing"}`, s.String())
+
+	tr2, err := j1215Plus.Unmarshal([]byte(s.String()))
+	require.NoError(t, err)
+	require.Equal(t, tr, tr2)
+}
+
+func TestJson_ModernContentTypes(t *testing.T) {
+	storage, _ := key.Parse("example:storage")
+	components := []Component{
+		&Score{Name: "@s", Objective: "kills", Value: "10"},
+		&Selector{Pattern: "@a", Separator: &Text{Content: ", "}},
+		&Keybind{Key: "key.jump"},
+		&BlockNBT{NBT: NBT{Path: "Items[0].id", Interpret: true, Separator: &Text{Content: " | "}}, Block: "~ ~ ~"},
+		&EntityNBT{NBT: NBT{Path: "Health", Plain: true}, Entity: "@s"},
+		&StorageNBT{NBT: NBT{Path: "value"}, Storage: storage},
+	}
+
+	for _, component := range components {
+		encoded := new(strings.Builder)
+		require.NoError(t, j1215Plus.Marshal(encoded, component))
+
+		decoded, err := j1215Plus.Unmarshal([]byte(encoded.String()))
+		require.NoError(t, err)
+		require.Equal(t, component, decoded)
+	}
+}
+
+func TestJson_DecodePrimitiveShorthand(t *testing.T) {
+	c, err := j1215Plus.Unmarshal([]byte(`true`))
+	require.NoError(t, err)
+	require.Equal(t, &Text{Content: "true"}, c)
+
+	c, err = j1215Plus.Unmarshal([]byte(`12`))
+	require.NoError(t, err)
+	require.Equal(t, &Text{Content: "12"}, c)
+}
+
+func TestJson_StyleShadowColor(t *testing.T) {
+	component := &Text{
+		Content: "Shadow",
+		S: Style{
+			ShadowColor: ShadowColorFromARGB(0x80445566),
+		},
+	}
+
+	encoded := new(strings.Builder)
+	require.NoError(t, j1215Plus.Marshal(encoded, component))
+	require.Equal(t, `{"shadow_color":-2143005338,"text":"Shadow"}`, encoded.String())
+
+	decoded, err := j1215Plus.Unmarshal([]byte(`{"shadow_color":[0.26666666666666666,0.3333333333333333,0.4,0.5019607843137255],"text":"Shadow"}`))
+	require.NoError(t, err)
+	require.Equal(t, component, decoded)
+}
+
+func TestJson_ShowItemModernComponents(t *testing.T) {
+	diamond, _ := key.Parse("minecraft:diamond")
+	component := &Text{
+		Content: "Hover",
+		S: Style{HoverEvent: ShowItem(&ShowItemHoverType{
+			Item:  diamond,
+			Count: 1,
+			Components: map[string]interface{}{
+				"minecraft:custom_name": map[string]interface{}{"text": "Spark"},
+			},
+		})},
+	}
+
+	encoded := new(strings.Builder)
+	require.NoError(t, j1215Plus.Marshal(encoded, component))
+	require.Equal(t, `{"hover_event":{"action":"show_item","components":{"minecraft:custom_name":{"text":"Spark"}},"count":1,"id":"minecraft:diamond"},"text":"Hover"}`, encoded.String())
+
+	decoded, err := j1215Plus.Unmarshal([]byte(encoded.String()))
+	require.NoError(t, err)
+	require.Equal(t, component, decoded)
+}
+
+func TestJson_ObjectComponent_AtlasSprite(t *testing.T) {
+	blocks, _ := key.Parse("minecraft:blocks")
+	diamond, _ := key.Parse("minecraft:item/diamond")
+	component := AtlasSprite(blocks, diamond)
+
+	encoded := new(strings.Builder)
+	err := j1215Plus.Marshal(encoded, component)
+	require.NoError(t, err)
+	require.Equal(t, `{"atlas":"minecraft:blocks","object":"atlas","sprite":"minecraft:item/diamond"}`, encoded.String())
+
+	decoded, err := j1215Plus.Unmarshal([]byte(encoded.String()))
+	require.NoError(t, err)
+	require.Equal(t, component, decoded)
+}
+
+func TestJson_ObjectComponent_DecodeAdventureSpriteShape(t *testing.T) {
+	decoded, err := j1215Plus.Unmarshal([]byte(`{"fallback":"diamond","sprite":"item/diamond"}`))
+	require.NoError(t, err)
+
+	diamond, _ := key.Parse("minecraft:item/diamond")
+	expected := AtlasSprite(DefaultSpriteAtlas, diamond)
+	expected.Fallback = &Text{Content: "diamond"}
+	require.Equal(t, expected, decoded)
+}
+
+func TestJson_ObjectComponent_PlayerHeadWithFallback(t *testing.T) {
+	id := uuid.MustParse("12345678-1234-1234-1234-123456789abc")
+	component := PlayerHead(&PlayerProfile{
+		Name: "jeb_",
+		Id:   id,
+	}, false)
+	component.Fallback = &Text{Content: "jeb_"}
+
+	encoded := new(strings.Builder)
+	err := j1215Plus.Marshal(encoded, component)
+	require.NoError(t, err)
+	require.Equal(t, `{"fallback":{"text":"jeb_"},"hat":false,"object":"player","player":{"id":"12345678-1234-1234-1234-123456789abc","name":"jeb_"}}`, encoded.String())
+
+	decoded, err := j1215Plus.Unmarshal([]byte(encoded.String()))
+	require.NoError(t, err)
+	require.Equal(t, component, decoded)
+}
+
+func TestJson_ObjectComponent_PlayerNameShortcut(t *testing.T) {
+	component := PlayerHead(&PlayerProfile{Name: "jeb_"}, true)
+
+	encoded := new(strings.Builder)
+	err := j1215Plus.Marshal(encoded, component)
+	require.NoError(t, err)
+	require.Equal(t, `{"hat":true,"object":"player","player":"jeb_"}`, encoded.String())
+
+	decoded, err := j1215Plus.Unmarshal([]byte(encoded.String()))
+	require.NoError(t, err)
+	require.Equal(t, component, decoded)
+}
+
 // Test encoding with new format (1.21.5+)
 func TestJson_Marshal_NewFormat(t *testing.T) {
 	b := new(strings.Builder)

--- a/minecraft/component/codec/json_test.go
+++ b/minecraft/component/codec/json_test.go
@@ -207,6 +207,63 @@ func TestJson_ShowItemModernComponents(t *testing.T) {
 	require.Equal(t, component, decoded)
 }
 
+func TestJson_ShowItemHoverDataMode(t *testing.T) {
+	diamond, _ := key.Parse("minecraft:diamond")
+	component := &Text{
+		Content: "Hover",
+		S: Style{HoverEvent: ShowItem(&ShowItemHoverType{
+			Item:  diamond,
+			Count: 1,
+			NBT:   nbt.NewBinaryTagHolder("{display:{Name:\"Legacy\"}}"),
+			Components: map[string]interface{}{
+				"minecraft:custom_name": map[string]interface{}{"text": "Modern"},
+			},
+		})},
+	}
+
+	t.Run("legacy_nbt", func(t *testing.T) {
+		encoded := new(strings.Builder)
+		require.NoError(t, (&Json{
+			UseLegacyFieldNames:          true,
+			UseLegacyHoverEventStructure: true,
+			ShowItemHoverDataMode:        ShowItemHoverDataModeLegacyNBT,
+			StdJson:                      true,
+		}).Marshal(encoded, component))
+		require.Contains(t, encoded.String(), `"tag":"{display:{Name:\"Legacy\"}}"`)
+		require.NotContains(t, encoded.String(), `"components"`)
+	})
+
+	t.Run("data_components", func(t *testing.T) {
+		encoded := new(strings.Builder)
+		require.NoError(t, (&Json{
+			UseLegacyFieldNames:          false,
+			UseLegacyHoverEventStructure: false,
+			EmitDefaultItemHoverQuantity: true,
+			ShowItemHoverDataMode:        ShowItemHoverDataModeDataComponents,
+			StdJson:                      true,
+		}).Marshal(encoded, component))
+		require.Contains(t, encoded.String(), `"components":{"minecraft:custom_name":{"text":"Modern"}}`)
+		require.NotContains(t, encoded.String(), `"tag"`)
+	})
+}
+
+func TestJson_ShowTextHoverAnyComponent(t *testing.T) {
+	component := &Text{
+		Content: "Hover",
+		S: Style{
+			HoverEvent: ShowText(&Translation{Key: "item.minecraft.diamond", Fallback: "Diamond"}),
+		},
+	}
+
+	encoded := new(strings.Builder)
+	require.NoError(t, j1215Plus.Marshal(encoded, component))
+	require.Equal(t, `{"hover_event":{"action":"show_text","value":{"fallback":"Diamond","translate":"item.minecraft.diamond"}},"text":"Hover"}`, encoded.String())
+
+	decoded, err := j1215Plus.Unmarshal([]byte(encoded.String()))
+	require.NoError(t, err)
+	require.Equal(t, component, decoded)
+}
+
 func TestJson_ObjectComponent_AtlasSprite(t *testing.T) {
 	blocks, _ := key.Parse("minecraft:blocks")
 	diamond, _ := key.Parse("minecraft:item/diamond")
@@ -215,7 +272,7 @@ func TestJson_ObjectComponent_AtlasSprite(t *testing.T) {
 	encoded := new(strings.Builder)
 	err := j1215Plus.Marshal(encoded, component)
 	require.NoError(t, err)
-	require.Equal(t, `{"atlas":"minecraft:blocks","object":"atlas","sprite":"minecraft:item/diamond"}`, encoded.String())
+	require.Equal(t, `{"atlas":"minecraft:blocks","sprite":"minecraft:item/diamond"}`, encoded.String())
 
 	decoded, err := j1215Plus.Unmarshal([]byte(encoded.String()))
 	require.NoError(t, err)
@@ -243,7 +300,7 @@ func TestJson_ObjectComponent_PlayerHeadWithFallback(t *testing.T) {
 	encoded := new(strings.Builder)
 	err := j1215Plus.Marshal(encoded, component)
 	require.NoError(t, err)
-	require.Equal(t, `{"fallback":{"text":"jeb_"},"hat":false,"object":"player","player":{"id":"12345678-1234-1234-1234-123456789abc","name":"jeb_"}}`, encoded.String())
+	require.Equal(t, `{"fallback":{"text":"jeb_"},"hat":false,"player":{"id":"12345678-1234-1234-1234-123456789abc","name":"jeb_"}}`, encoded.String())
 
 	decoded, err := j1215Plus.Unmarshal([]byte(encoded.String()))
 	require.NoError(t, err)
@@ -256,11 +313,24 @@ func TestJson_ObjectComponent_PlayerNameShortcut(t *testing.T) {
 	encoded := new(strings.Builder)
 	err := j1215Plus.Marshal(encoded, component)
 	require.NoError(t, err)
-	require.Equal(t, `{"hat":true,"object":"player","player":"jeb_"}`, encoded.String())
+	require.Equal(t, `{"hat":true,"player":"jeb_"}`, encoded.String())
 
 	decoded, err := j1215Plus.Unmarshal([]byte(encoded.String()))
 	require.NoError(t, err)
 	require.Equal(t, component, decoded)
+}
+
+func TestJson_ObjectComponent_PlayerPropertiesMap(t *testing.T) {
+	decoded, err := j1215Plus.Unmarshal([]byte(`{"player":{"name":"jeb_","properties":{"textures":["value-a","value-b"]}}}`))
+	require.NoError(t, err)
+
+	require.Equal(t, PlayerHead(&PlayerProfile{
+		Name: "jeb_",
+		Properties: []ProfileProperty{
+			{Name: "textures", Value: "value-a"},
+			{Name: "textures", Value: "value-b"},
+		},
+	}, true), decoded)
 }
 
 // Test encoding with new format (1.21.5+)

--- a/minecraft/component/codec/json_test.go
+++ b/minecraft/component/codec/json_test.go
@@ -2,6 +2,7 @@ package codec
 
 import (
 	"io/ioutil"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -80,10 +81,10 @@ var (
 		}}
 
 	// New format JSON (1.21.5+) - uses snake_case field names and new structures
-	jsonTxtNew = `{"bold":false,"click_event":{"action":"suggest_command","command":"/help"},"color":"#55ffff","extra":[{"color":"#ff5555","italic":true,"obfuscated":false,"text":" there!"}],"font":"minecraft:default","hover_event":{"action":"show_text","value":{"extra":[{"text":"!"}],"text":" world"}},"insertion":"insert me","italic":false,"obfuscated":true,"text":"Hello","underlined":true}`
+	jsonTxtNew = `{"bold":false,"click_event":{"action":"suggest_command","command":"/help"},"color":"#55ffff","extra":[{"color":"#ff5555","italic":true,"obfuscated":false,"text":" there!"}],"font":"minecraft:default","hover_event":{"action":"show_text","value":{"extra":["!"],"text":" world"}},"insertion":"insert me","italic":false,"obfuscated":true,"text":"Hello","underlined":true}`
 
 	// Legacy format JSON (pre-1.21.5) - uses camelCase field names and legacy structures
-	jsonTxtLegacy = `{"bold":false,"clickEvent":{"action":"suggest_command","value":"/help"},"color":"#55ffff","extra":[{"color":"#ff5555","italic":true,"obfuscated":false,"text":" there!"}],"font":"minecraft:default","hoverEvent":{"action":"show_text","contents":{"extra":[{"text":"!"}],"text":" world"},"value":{"extra":[{"text":"!"}],"text":" world"}},"insertion":"insert me","italic":false,"obfuscated":true,"text":"Hello","underlined":true}`
+	jsonTxtLegacy = `{"bold":false,"clickEvent":{"action":"suggest_command","value":"/help"},"color":"#55ffff","extra":[{"color":"#ff5555","italic":true,"obfuscated":false,"text":" there!"}],"font":"minecraft:default","hoverEvent":{"action":"show_text","contents":{"extra":["!"],"text":" world"},"value":{"extra":["!"],"text":" world"}},"insertion":"insert me","italic":false,"obfuscated":true,"text":"Hello","underlined":true}`
 )
 
 func TestJson_Marshal_text(t *testing.T) {
@@ -129,7 +130,7 @@ func TestJson_translation(t *testing.T) {
 	}
 	s := new(strings.Builder)
 	require.NoError(t, j1215Plus.Marshal(s, tr))
-	const exp = `{"color":"#ff5555","translate":"sample.key","with":[{"text":"Hello"},{"translate":"another.key"}]}`
+	const exp = `{"color":"#ff5555","translate":"sample.key","with":["Hello",{"translate":"another.key"}]}`
 	require.Equal(t, exp, s.String())
 
 	tr2, err := j1215Plus.Unmarshal([]byte(exp))
@@ -221,6 +222,29 @@ func TestJson_ShowItemModernComponents(t *testing.T) {
 	require.Equal(t, component, decoded)
 }
 
+func TestJson_ShowItemModernComponentsWithGojay(t *testing.T) {
+	diamond, _ := key.Parse("minecraft:diamond")
+	component := &Text{
+		Content: "Hover",
+		S: Style{HoverEvent: ShowItem(&ShowItemHoverType{
+			Item:  diamond,
+			Count: 1,
+			Components: map[string]interface{}{
+				"minecraft:custom_name": map[string]interface{}{"text": "Spark"},
+			},
+		})},
+	}
+
+	encoded := new(strings.Builder)
+	require.NoError(t, (&Json{
+		UseLegacyFieldNames:          false,
+		UseLegacyHoverEventStructure: false,
+		EmitDefaultItemHoverQuantity: true,
+		ShowItemHoverDataMode:        ShowItemHoverDataModeDataComponents,
+	}).Marshal(encoded, component))
+	require.JSONEq(t, `{"hover_event":{"action":"show_item","components":{"minecraft:custom_name":{"text":"Spark"}},"count":1,"id":"minecraft:diamond"},"text":"Hover"}`, encoded.String())
+}
+
 func TestJson_ShowItemHoverDataMode(t *testing.T) {
 	diamond, _ := key.Parse("minecraft:diamond")
 	component := &Text{
@@ -259,6 +283,98 @@ func TestJson_ShowItemHoverDataMode(t *testing.T) {
 		require.Contains(t, encoded.String(), `"components":{"minecraft:custom_name":{"text":"Modern"}}`)
 		require.NotContains(t, encoded.String(), `"tag"`)
 	})
+}
+
+func TestJson_ShowEntityUUIDIntArray(t *testing.T) {
+	entityID := uuid.MustParse("12345678-1234-1234-1234-123456789abc")
+	entityKey, _ := key.Parse("minecraft:player")
+	component := &Text{
+		Content: "Hover for entity",
+		S: Style{HoverEvent: ShowEntity(&ShowEntityHoverType{
+			Type: entityKey,
+			Id:   entityID,
+			Name: &Text{Content: "TestPlayer"},
+		})},
+	}
+
+	encoded := new(strings.Builder)
+	require.NoError(t, (&Json{
+		UseLegacyFieldNames:                     false,
+		UseLegacyHoverEventStructure:            false,
+		EmitCompactTextComponent:                true,
+		EmitHoverShowEntityIdAsIntArray:         true,
+		EmitHoverShowEntityKeyAsTypeAndUuidAsId: false,
+		StdJson:                                 true,
+	}).Marshal(encoded, component))
+	require.JSONEq(t, `{"hover_event":{"action":"show_entity","id":"minecraft:player","name":"TestPlayer","uuid":[305419896,305402420,305402420,1450744508]},"text":"Hover for entity"}`, encoded.String())
+
+	decoded, err := j1215Plus.Unmarshal([]byte(encoded.String()))
+	require.NoError(t, err)
+	require.Equal(t, component, decoded)
+}
+
+func TestJson_EmitCompactTextComponent(t *testing.T) {
+	encoded := new(strings.Builder)
+	require.NoError(t, (&Json{
+		EmitCompactTextComponent: true,
+		StdJson:                  true,
+	}).Marshal(encoded, &Text{Content: "plain"}))
+	require.Equal(t, `"plain"`, encoded.String())
+
+	component := &Text{
+		Content: "root",
+		Extra: []Component{
+			&Text{Content: " child"},
+			&Text{Content: " styled", S: Style{Bold: True}},
+		},
+	}
+	encoded.Reset()
+	require.NoError(t, (&Json{
+		EmitCompactTextComponent: true,
+		StdJson:                  true,
+	}).Marshal(encoded, component))
+	require.JSONEq(t, `{"extra":[" child",{"bold":true,"text":" styled"}],"text":"root"}`, encoded.String())
+}
+
+type testClickAction struct {
+	name     string
+	readable bool
+}
+
+func (a testClickAction) Name() string   { return a.name }
+func (a testClickAction) Readable() bool { return a.readable }
+
+type testHoverAction struct {
+	name     string
+	readable bool
+}
+
+func (a testHoverAction) Name() string { return a.name }
+func (a testHoverAction) Type() ActionType {
+	return ActionType(reflect.TypeOf(Text{}))
+}
+func (a testHoverAction) Readable() bool { return a.readable }
+
+func TestJson_ValidateStrictEvents(t *testing.T) {
+	strict := &Json{ValidateStrictEvents: true, StdJson: true}
+
+	err := strict.Marshal(new(strings.Builder), &Text{
+		Content: "bad click",
+		S:       Style{ClickEvent: NewClickEvent(testClickAction{name: "not_real", readable: true}, "value")},
+	})
+	require.ErrorContains(t, err, "unsupported click event action")
+
+	err = strict.Marshal(new(strings.Builder), &Text{
+		Content: "bad hover",
+		S:       Style{HoverEvent: NewHoverEvent(testHoverAction{name: "not_real", readable: true}, &Text{Content: "hover"})},
+	})
+	require.ErrorContains(t, err, "unsupported hover event action")
+
+	_, err = strict.Unmarshal([]byte(`{"text":"bad","click_event":{"action":"not_real","value":"x"}}`))
+	require.ErrorContains(t, err, "unsupported click event action")
+
+	_, err = strict.Unmarshal([]byte(`{"text":"bad","hover_event":{"action":"not_real","value":{"text":"x"}}}`))
+	require.ErrorContains(t, err, "unsupported hover event action")
 }
 
 func TestJson_ShowTextHoverAnyComponent(t *testing.T) {
@@ -757,8 +873,8 @@ func TestJson_HoverEvent_AllActions(t *testing.T) {
 			require.Contains(t, encoded.String(), `"hoverEvent"`)
 			require.Contains(t, encoded.String(), `"action":"show_entity"`)
 			require.Contains(t, encoded.String(), `"contents"`)
-			require.Contains(t, encoded.String(), `"type":"minecraft:player"`)                   // Legacy field name
-			require.Contains(t, encoded.String(), `"id":"12345678-1234-1234-1234-123456789abc"`) // Legacy field name
+			require.Contains(t, encoded.String(), `"type":"minecraft:player"`) // Legacy field name
+			require.Contains(t, encoded.String(), `"id":[305419896,305402420,305402420,1450744508]`)
 
 			decoded, err := jPre1215.Unmarshal([]byte(encoded.String()))
 			require.NoError(t, err)
@@ -774,8 +890,8 @@ func TestJson_HoverEvent_AllActions(t *testing.T) {
 			// Should contain new inlined structure with new field names
 			require.Contains(t, encoded.String(), `"hover_event"`)
 			require.Contains(t, encoded.String(), `"action":"show_entity"`)
-			require.Contains(t, encoded.String(), `"id":"minecraft:player"`)                       // New field name (was "type")
-			require.Contains(t, encoded.String(), `"uuid":"12345678-1234-1234-1234-123456789abc"`) // New field name (was "id")
+			require.Contains(t, encoded.String(), `"id":"minecraft:player"`) // New field name (was "type")
+			require.Contains(t, encoded.String(), `"uuid":[305419896,305402420,305402420,1450744508]`)
 			require.NotContains(t, encoded.String(), `"contents"`)
 			require.NotContains(t, encoded.String(), `"type":"minecraft:player"`) // Should not use legacy field name
 

--- a/minecraft/component/codec/json_test.go
+++ b/minecraft/component/codec/json_test.go
@@ -375,6 +375,12 @@ func TestJson_ValidateStrictEvents(t *testing.T) {
 
 	_, err = strict.Unmarshal([]byte(`{"text":"bad","hover_event":{"action":"not_real","value":{"text":"x"}}}`))
 	require.ErrorContains(t, err, "unsupported hover event action")
+
+	_, err = strict.Unmarshal([]byte(`{"text":"bad","click_event":{"action":"run_command"}}`))
+	require.ErrorContains(t, err, "missing value for click event action")
+
+	_, err = strict.Unmarshal([]byte(`{"text":"bad","hover_event":{"action":"show_item"}}`))
+	require.ErrorContains(t, err, "missing value for hover event action")
 }
 
 func TestJson_ShowTextHoverAnyComponent(t *testing.T) {

--- a/minecraft/component/codec/json_test.go
+++ b/minecraft/component/codec/json_test.go
@@ -99,6 +99,20 @@ func TestJson_Unmarshal_text(t *testing.T) {
 	require.Equal(t, txt, c)
 }
 
+func TestJson_Unmarshal_NBTStyleDecorationBooleans(t *testing.T) {
+	c, err := j1215Plus.Unmarshal([]byte(`{"text":"Hello","obfuscated":"1B","italic":"0B","underlined":1,"bold":0}`))
+	require.NoError(t, err)
+	require.Equal(t, &Text{
+		Content: "Hello",
+		S: Style{
+			Obfuscated: True,
+			Italic:     False,
+			Underlined: True,
+			Bold:       False,
+		},
+	}, c)
+}
+
 func TestJson_translation(t *testing.T) {
 	tr := &Translation{
 		Key: "sample.key",

--- a/minecraft/component/component.go
+++ b/minecraft/component/component.go
@@ -19,9 +19,10 @@ type Text struct {
 }
 
 type Translation struct {
-	Key  string // Translation key
-	S    Style
-	With []Component
+	Key      string // Translation key
+	Fallback string
+	S        Style
+	With     []Component
 }
 
 func (t *Text) Children() []Component {

--- a/minecraft/component/component.go
+++ b/minecraft/component/component.go
@@ -20,9 +20,9 @@ type Text struct {
 
 type Translation struct {
 	Key      string // Translation key
-	Fallback string
 	S        Style
 	With     []Component
+	Fallback string
 }
 
 func (t *Text) Children() []Component {

--- a/minecraft/component/content.go
+++ b/minecraft/component/content.go
@@ -1,0 +1,96 @@
+package component
+
+import "go.minekube.com/common/minecraft/key"
+
+type Score struct {
+	Name      string
+	Objective string
+	Value     string
+	S         Style
+	Extra     []Component
+}
+
+func (s *Score) Children() []Component {
+	return s.Extra
+}
+
+func (s *Score) Style() *Style {
+	return &s.S
+}
+
+func (s *Score) SetChildren(children []Component) {
+	s.Extra = children
+}
+
+type Selector struct {
+	Pattern   string
+	Separator Component
+	S         Style
+	Extra     []Component
+}
+
+func (s *Selector) Children() []Component {
+	return s.Extra
+}
+
+func (s *Selector) Style() *Style {
+	return &s.S
+}
+
+func (s *Selector) SetChildren(children []Component) {
+	s.Extra = children
+}
+
+type Keybind struct {
+	Key   string
+	S     Style
+	Extra []Component
+}
+
+func (k *Keybind) Children() []Component {
+	return k.Extra
+}
+
+func (k *Keybind) Style() *Style {
+	return &k.S
+}
+
+func (k *Keybind) SetChildren(children []Component) {
+	k.Extra = children
+}
+
+type NBT struct {
+	Path      string
+	Interpret bool
+	Plain     bool
+	Separator Component
+	S         Style
+	Extra     []Component
+}
+
+type BlockNBT struct {
+	NBT
+	Block string
+}
+
+type EntityNBT struct {
+	NBT
+	Entity string
+}
+
+type StorageNBT struct {
+	NBT
+	Storage key.Key
+}
+
+func (n *NBT) Children() []Component {
+	return n.Extra
+}
+
+func (n *NBT) Style() *Style {
+	return &n.S
+}
+
+func (n *NBT) SetChildren(children []Component) {
+	n.Extra = children
+}

--- a/minecraft/component/hover.go
+++ b/minecraft/component/hover.go
@@ -72,9 +72,10 @@ func (a *hoverAction) String() string {
 }
 
 type ShowItemHoverType struct {
-	Item  key.Key
-	Count int
-	NBT   nbt.BinaryTagHolder // nil-able
+	Item       key.Key
+	Count      int
+	NBT        nbt.BinaryTagHolder // nil-able
+	Components map[string]interface{}
 }
 
 type ShowEntityHoverType struct {

--- a/minecraft/component/object.go
+++ b/minecraft/component/object.go
@@ -1,0 +1,75 @@
+package component
+
+import (
+	"github.com/google/uuid"
+	"go.minekube.com/common/minecraft/key"
+)
+
+var DefaultSpriteAtlas = key.New(key.MinecraftNamespace, "blocks")
+
+type Object struct {
+	Contents ObjectContents
+	S        Style
+	Extra    []Component
+	Fallback Component
+}
+
+func (o *Object) Children() []Component {
+	return o.Extra
+}
+
+func (o *Object) Style() *Style {
+	return &o.S
+}
+
+func (o *Object) SetChildren(children []Component) {
+	o.Extra = children
+}
+
+type ObjectContents interface {
+	objectContents()
+}
+
+type SpriteObjectContents struct {
+	Atlas  key.Key
+	Sprite key.Key
+}
+
+func (*SpriteObjectContents) objectContents() {}
+
+func AtlasSprite(atlas, sprite key.Key) *Object {
+	if atlas == nil {
+		atlas = DefaultSpriteAtlas
+	}
+	return &Object{Contents: &SpriteObjectContents{
+		Atlas:  atlas,
+		Sprite: sprite,
+	}}
+}
+
+type PlayerHeadObjectContents struct {
+	Profile *PlayerProfile
+	Hat     bool
+}
+
+func (*PlayerHeadObjectContents) objectContents() {}
+
+type PlayerProfile struct {
+	Name       string
+	Id         uuid.UUID
+	Properties []ProfileProperty
+	Texture    key.Key
+}
+
+type ProfileProperty struct {
+	Name      string
+	Value     string
+	Signature string
+}
+
+func PlayerHead(profile *PlayerProfile, hat bool) *Object {
+	return &Object{Contents: &PlayerHeadObjectContents{
+		Profile: profile,
+		Hat:     hat,
+	}}
+}

--- a/minecraft/component/style.go
+++ b/minecraft/component/style.go
@@ -13,11 +13,12 @@ var (
 type Style struct {
 	Obfuscated, Bold, Strikethrough, Underlined, Italic State
 
-	Font       key.Key
-	Color      color.Color
-	ClickEvent ClickEvent
-	HoverEvent HoverEvent
-	Insertion  *string // Gets the string to be inserted when this component is shift-clicked.
+	Font        key.Key
+	Color       color.Color
+	ShadowColor *ShadowColor
+	ClickEvent  ClickEvent
+	HoverEvent  HoverEvent
+	Insertion   *string // Gets the string to be inserted when this component is shift-clicked.
 }
 
 // IsZero reports whether the Style is the zero value.
@@ -30,6 +31,7 @@ func (s *Style) IsZero() bool {
 			s.Italic == NotSet &&
 			s.Font == nil &&
 			s.Color == nil &&
+			s.ShadowColor == nil &&
 			s.ClickEvent == nil &&
 			s.HoverEvent == nil &&
 			s.Insertion == nil)
@@ -92,4 +94,12 @@ func StateByBool(b bool) State {
 		return True
 	}
 	return False
+}
+
+type ShadowColor struct {
+	ARGB uint32
+}
+
+func ShadowColorFromARGB(argb int) *ShadowColor {
+	return &ShadowColor{ARGB: uint32(argb)}
 }

--- a/minecraft/component/style.go
+++ b/minecraft/component/style.go
@@ -13,12 +13,13 @@ var (
 type Style struct {
 	Obfuscated, Bold, Strikethrough, Underlined, Italic State
 
-	Font        key.Key
-	Color       color.Color
+	Font       key.Key
+	Color      color.Color
+	ClickEvent ClickEvent
+	HoverEvent HoverEvent
+	Insertion  *string // Gets the string to be inserted when this component is shift-clicked.
+
 	ShadowColor *ShadowColor
-	ClickEvent  ClickEvent
-	HoverEvent  HoverEvent
-	Insertion   *string // Gets the string to be inserted when this component is shift-clicked.
 }
 
 // IsZero reports whether the Style is the zero value.


### PR DESCRIPTION
## Summary
- add modern component types: score, selector, keybind, block/entity/storage NBT, and object components
- support translation/object fallbacks, atlas sprites, player heads, shadow colors, primitive shorthand decoding, compact text emission, UUID int-array show_entity hovers, strict event validation, and modern show_item data components
- update JSON presets and README with the modern support matrix and examples

## Context
- Mojang added object text components for atlas sprites/player heads in 1.21.9 snapshots and 26.1 added object fallback plus MOTD behavior notes.
- Adventure's current serializer constants/implementation cover the same modern keys, including atlas, sprite, player, hat, fallback, score, selector, keybind, NBT, shadow_color, and show_item components.
- Supersedes older component PRs #12, #13, #14, and #15; the useful #15 decoration bool compatibility behavior was carried forward.

## Compatibility notes
- Existing preset names stay in place; legacy presets continue to emit legacy NBT show_item data.
- This adds exported fields to existing structs for new protocol data. Keyed literals are unaffected, but downstream unkeyed positional struct literals may need to switch to keyed literals or include the new fields.
- Gate adoption is tracked separately in minekube/gate#810 after this PR is merged and Common is released.

## Verification
- git diff --check
- go test ./...
- make
- subagent review after rebase; blocking findings fixed in 79668ee and f2d23c4